### PR TITLE
Dev (GYSFDMAXBクラス)

### DIFF
--- a/parts/GPS/GYSFDMAXB/README-ja.md
+++ b/parts/GPS/GYSFDMAXB/README-ja.md
@@ -3,7 +3,7 @@
 
 GPSモジュール[(GYSFDMAXB(太陽誘電))](http://akizukidenshi.com/catalog/g/gK-09991/)から情報を取得するライブラリです。
 
-![](./image.jpg) 
+![](./image.jpg)
 
 
 
@@ -36,10 +36,62 @@ gps.start1pps(function() {
 ```
 
 
+## getGpsInfo({editedData})
+
+受信したNMEAフォーマットのセンテンスから有用なデータをオブジェクト化した結果を取り出します。同じ情報が`gpsInfo`プロパティにもセットされます。<br>
+通常は引数を省略しますが、後述の`editedData`を指定すると、その情報を使用してオブジェクト化します。
+
+```javascript
+// Javascript Example
+let gps = obniz.wired("GYSFDMAXB", { vcc:7, gnd:8, txd:9, rxd:10, Opps:11 });
+let gpsInfo = getGpsInfo();
+console.log(gpsInfo);
+
+// 出力結果
+gpsInfo: Object
+  utc: Sat Sep 08 2018 22:42:14 GMT+0900 (JST)
+  status: A [Active]	// Active or Void
+  fixMode: 3 [3D]	// 1:Fix not available, 2:2D, 3:3D
+  gpsQuality: 2 [DGPS fix]	// 0:Invalid, 1:GPS fix, 2:DGPS fix
+  latitude: 35.999999
+  longitude: 139.999999
+  pdop: 1.24	// PDOP: Position Dilution of Precision
+  hdop: 0.97	// HDOP: Horizontal Dilution of Precision
+  vdop: 0.77	// VDOP: Vertical Dilution of Position
+  altitude: 57.4[M]
+  declination: NaN	// Magnetic declination
+  direction: 236.34
+  speed: 0.02[km/h]
+  satelliteInfo: Object
+    inUse: 11
+    inView: 15
+    satellites: Array (15)
+      [0]: {id: 194,	elevation: 87,	azimuth: 261,	snr: 31[dB],	inUse: true, }
+      [1]: {id: 25,	elevation: 63,	azimuth: 179,	snr: 34[dB],	inUse: true, }
+      [2]: {id: 12,	elevation: 59,	azimuth: 67,	snr: 20[dB],	inUse: true, }
+      [3]: {id: 193,	elevation: 59,	azimuth: 210,	snr: 37[dB],	inUse: true, }
+      [4]: {id: 10,	elevation: 55,	azimuth: 256,	snr: 40[dB],	inUse: true, }
+      [5]: {id: 42,	elevation: 48,	azimuth: 170,	snr: 31[dB],	inUse: false, }
+      [6]: {id: 20,	elevation: 43,	azimuth: 211,	snr: 35[dB],	inUse: true, }
+      [7]: {id: 32,	elevation: 41,	azimuth: 315,	snr: 46[dB],	inUse: true, }
+      [8]: {id: 24,	elevation: 35,	azimuth: 57,	snr: NaN[dB],	inUse: false, }
+      [9]: {id: 15,	elevation: 25,	azimuth: 120,	snr: 23[dB],	inUse: true, }
+      [10]: {id: 14,	elevation: 19,	azimuth: 307,	snr: 30[dB],	inUse: true, }
+      [11]: {id: 195,	elevation: 18,	azimuth: 168,	snr: 28[dB],	inUse: true, }
+      [12]: {id: 31,	elevation: 12,	azimuth: 260,	snr: 24[dB],	inUse: true, }
+      [13]: {id: 19,	elevation: 5,	azimuth: 46,	snr: NaN[dB],	inUse: false, }
+      [14]: {id: 29,	elevation: 1,	azimuth: 160,	snr: NaN[dB],	inUse: false, }
+  sentences: Set {GPGGA, GPGSA, GPGSV, GPRMC, GPVTG, GPZDA, }
+
+```
+
 ## readSentence()
 
 受信したGPSデータ([NMEAフォーマット](https://ja.wikipedia.org/wiki/NMEA_0183))の1センテンス(1行の)データを読み出します。データがない場合は、空文字が返ります。
-NMEAフォーマットのデータを直接使いたい場合にこのAPIを使いますが、通常は次の`getEditedData()`を使う方が便利です。
+NMEAフォーマットのデータを直接使いたい場合にこのAPIを使います。
+
+受信した1センテンス分のデータが文字列としてセットされます。<br>
+**例：** "$GPGGA,134214.000,3599.9999,N,13999.9999,E,2,11,0.97,57.4,M,39.5,M,,\*5C"
 
 
 ```javascript
@@ -50,7 +102,7 @@ let sentence = gps.readSentence();
 
 ## getEditedData()
 
-受信したNMEAフォーマットを編集しオブジェクト化した結果を取り出します。同じ情報が`editedData`プロパティにもセットされます。
+受信したNMEAフォーマットのセンテンスをオブジェクト化した結果を取り出します。同じ情報が`editedData`プロパティにもセットされます。
 
 - editedData.enable : 以下が有効なデータを保持している場合true
 - editedData.GPGGA : GPGGAセンテンスデータ
@@ -62,6 +114,12 @@ let sentence = gps.readSentence();
 - editedData.GPZDA : GPZDAセンテンスデータ
 - editedData.xxx : その他xxxセンテンスデータ
 - editedData.timestamp : GPZDAセンテンスの日付時刻情報（Date型）
+
+各センテンスのデータが文字配列としてセットされます。<br>
+**例：** $GPGGA,134214.000,3599.9999,N,13999.9999,E,2,11,0.97,57.4,M,39.5,M,,\*5C
+<br>
+["$GPGGA","134214.000","3599.9999","N","13999.9999","E","2","11","0.97","57.4","M","39.5","M","","*5C"]
+
 
 ```javascript
 // Javascript Example
@@ -83,14 +141,14 @@ function mainLoop() {
     if (data.PMTK010)  console.log(data.PMTK010.join(","));
     if (data.PMTK011)  console.log(data.PMTK011.join(","));
   }
-  setTimeout(mainLoop, 100);
+  setTimeout(mainLoop, 1000);
 }
 
 setTimeout(mainLoop, 10);
 ```
 
 
-## staticメソッド
+## 経度・緯度情報の単位変換メソッド
 
 NMEAフォーマットの経度・緯度情報の単位変換を提供します。
 
@@ -101,10 +159,10 @@ NMEAの緯度経度を「度分秒(DMS)」の文字列に変換（999°99'99.9"�
 NMEAの緯度経度を「度分(DM)」の文字列に変換（999°99.9999'）
 
 - nmea2dd(value)<br>
-NMEAの緯度経度を「度(DD)」の文字列に変換（999.999999）
+NMEAの緯度経度を「度(DD)」の数値に変換（999.999999）
 
 - nmea2s(value)<br>
-NMEAの緯度経度を「秒(S)」の数値に変換（0.999999999）
+NMEAの緯度経度を「秒(S)」の数値に変換（999999.999）
 
 
 ```javascript
@@ -116,9 +174,9 @@ NMEAの緯度経度を「秒(S)」の数値に変換（0.999999999）
       let p = d.GPGGA;
       if (p[6] != "0") {
         //経度
-        let longitude = GYSFDMAXB.nmea2s(p[2]);
+        let longitude = gps.nmea2dd(p[2]);
         //緯度
-        let latitude = GYSFDMAXB.nmea2s(p[4]);
+        let latitude = gps.nmea2dd(p[4]);
         
         ・・・
         
@@ -130,8 +188,10 @@ NMEAの緯度経度を「秒(S)」の数値に変換（0.999999999）
 
 [参考サイト](https://www.petitmonte.com/robot/howto_gysfdmaxb.html)
 
+
 ---
 
 Merged Pull Request
 
 [https://github.com/obniz/obniz/pull/127](https://github.com/obniz/obniz/pull/127)
+

--- a/parts/GPS/GYSFDMAXB/exsample.html
+++ b/parts/GPS/GYSFDMAXB/exsample.html
@@ -1,0 +1,394 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="https://obniz.io/js/jquery-3.2.1.min.js"></script>
+<script src="https://unpkg.com/obniz@1.10.0/obniz.js" crossorigin="anonymous"></script>
+<style>
+.opps {
+  padding: 1em 0.5em;
+  text-align: center;
+  text-decoration: none;
+  color: silver;
+  border: 2px solid silver;
+  font-size: 24px;
+  display: inline-block;
+  border-radius: 6em;
+  margin: 10px;
+}
+.opps1After {
+  background-color: red;
+  color: white;
+  border: 4px solid white;
+}
+.flexbox {
+  display: -webkit-box;   /* Chrome 4-20, Firefox 2-21, Safari 3.1-6.0 */
+  display: -webkit-flex;  /* Chrome 21-27 */
+  display: -moz-box;      /* Firefox 2-21 */
+  display: -ms-flexbox;   /* IE9 */
+  display: flex;
+}
+.flex-start {
+  -webkit-align-items: flex-start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+}
+</style>
+</head>
+<body style="background-color: white;">
+
+<div id="obniz-debug"></div>
+<h1>GYSFDMAXB GPS module</h1>
+<div style="display:block;"><iframe id="map" src="https://www.google.com/maps?output=embed&iwloc=B&q=35.710132,139.703268&t=m&z=18"
+    width="400" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>
+<td><button id="reMap">Mapping</button></td>
+</div>
+<small>
+<div id="addr"></div>
+</small>
+<div>
+<h3><span id="timestamp"></span>&nbsp;&nbsp;&nbsp;&nbsp;測位品質: <span id="quality">no available</span></h3>
+</div>
+<div style="display:block;" id="canvasDiv">
+<div><canvas id="canvas0" width="120" height="120" frameborder="0" style="border:0"></canvas>
+    <canvas id="canvas1" width="430" height="120" frameborder="0" style="border:0"></canvas></div>
+<div class="flexbox flex-start"><canvas id="canvas2" width="320" height="320" frameborder="0" style="border:0"></canvas>
+    <a id="opps" class="opps">1pps</a></div>
+</div>
+
+<h2 id="founds"></h2>
+<div id="print"></div>
+<h3>GPS情報</h3>
+<div style="font-size:large"><pre id="text1"></pre></div>
+<table><tr>
+  <td><h3>NMEAセンテンス</h3></td>
+  <td><button id="clear">Clear</button></td>
+</tr></table>
+<div id="display"></div>
+<div style="font-size:large"><pre id="text2"></pre></div>
+<table><tr>
+  <td><h3>GPS<br>power</h3></td>
+  <td><button id="on">ON</button></td>
+  <td><button id="off">OFF</button></td>
+  <td><button id="log">Log Start/Stop</button></td>
+</tr></table>
+
+<script>
+'use strict';
+var tapORclick = (window.ontouchstart===null) ? "touchstart" : "click";
+var obniz = new Obniz("OBNIZ_ID_HERE");
+obniz.onconnect = async function () {
+
+  var logging = false;
+  var showMap = true;
+  Obniz.PartsRegistrate(GYSFDMAXB_2);
+  var gps = obniz.wired("GYSFDMAXB_2", { vcc:7, gnd:8, txd:9, rxd:10, Opps:11 });
+
+  var gpsInfo;
+
+  gps.start1pps(function() {
+ // console.log("1pps received.");
+    $('#opps').addClass('opps1After');
+    setTimeout(function() {
+      $('#opps').removeClass('opps1After');
+    }, 200);
+  });
+  
+  function d2(v) {
+    return ('0' + v).slice(-2);
+  }
+  function localDatetime(d) {
+    let local = d.getFullYear() + "."
+        + d2(d.getMonth() + 1)  + "."
+        + d2(d.getDate())  + " "
+        + d2(d.getHours())  + ":"
+        + d2(d.getMinutes()) + ":"
+        + d2(d.getSeconds());
+    return local;
+  }
+
+  function mainLoop() {
+    let info = gps.getGpsInfo();
+    if (logging) {
+      console.log(gps.editedData);
+      console.log(info);
+    }
+    if (gps.editedData.enable) {
+      var nmea = "";
+      if (gps.editedData.GPGGA)     nmea += (gps.editedData.GPGGA.join(",") + "\n");
+      if (gps.editedData.GPGLL)     nmea += (gps.editedData.GPGLL.join(",") + "\n");
+      if (gps.editedData.GPGSA)     nmea += (gps.editedData.GPGSA.join(",") + "\n");
+      if (gps.editedData.GPGSV[0])  nmea += (gps.editedData.GPGSV[0].join(",") + "\n");
+      if (gps.editedData.GPGSV[1]) 	nmea += (gps.editedData.GPGSV[1].join(",") + "\n");
+      if (gps.editedData.GPGSV[2]) 	nmea += (gps.editedData.GPGSV[2].join(",") + "\n");
+      if (gps.editedData.GPGSV[3]) 	nmea += (gps.editedData.GPGSV[3].join(",") + "\n");
+      if (gps.editedData.GPRMC)     nmea += (gps.editedData.GPRMC.join(",") + "\n");
+      if (gps.editedData.GPVTG)     nmea += (gps.editedData.GPVTG.join(",") + "\n");
+      if (gps.editedData.GPZDA)     nmea += (gps.editedData.GPZDA.join(",") + "\n");
+      if (gps.editedData.PMTK010)   nmea += (gps.editedData.PMTK010.join(",") + "\n");
+      if (gps.editedData.PMTK011)   nmea += (gps.editedData.PMTK011.join(",") + "\n");
+      $("#text2").text(nmea);
+    }
+    if (info.status == "A") {
+      var inf = "gpsInfo\n" +
+      `  utc: ${info.utc}\n` +
+      `  status: ${info.status} [${gps.status2string(info.status)}]\t// Active or Void\n` +
+      `  fixMode: ${info.fixMode} [${gps.fixMode2string(info.fixMode)}]\t// 1:Fix not available, 2:2D, 3:3D\n` +
+      `  gpsQuality: ${info.gpsQuality} [${gps.gpsQuality2string(info.gpsQuality)}]\t// 0:Invalid, 1:GPS fix, 2:DGPS fix\n` +
+      `  latitude: ${info.latitude}\n` +
+      `  longitude: ${info.longitude}\n` +
+      `  pdop: ${info.pdop}\t// PDOP: Position Dilution of Precision\n` +
+      `  hdop: ${info.hdop}\t// HDOP: Horizontal Dilution of Precision\n` +
+      `  vdop: ${info.vdop}\t// VDOP: Vertical Dilution of Position\n` +
+      `  altitude: ${info.altitude}[M]\n` +
+      `  declination: ${info.declination}\t// Magnetic declination\n` +
+      `  direction: ${info.direction}\n` +
+      `  speed: ${info.speed}[km/h]\n` +
+      "  satelliteInfo:\n" +
+      `    inUse: ${info.satelliteInfo.inUse}\n` +
+      `    inView: ${info.satelliteInfo.inView}\n` +
+      `    satellites: Array (${info.satelliteInfo.satellites.length})\n`;
+      for (let n=0; n<info.satelliteInfo.satellites.length;n++) {
+        let sat = info.satelliteInfo.satellites[n];
+        inf += `      [${n}]: {id: ${sat.id},\televation: ${sat.elevation},\tazimuth: ${sat.azimuth},\tsnr: ${sat.snr}[dB],\tinUse: ${sat.inUse}, }\n`;
+      }
+
+      var set = "";
+      info.sentences.forEach(function(value) {
+        if (value == info._sentenceType.GPGGA) set += "GPGGA, ";
+        if (value == info._sentenceType.GPGGA) set += "GPGSA, ";
+        if (value == info._sentenceType.GPGGA) set += "GPGSV, ";
+        if (value == info._sentenceType.GPGGA) set += "GPRMC, ";
+        if (value == info._sentenceType.GPGGA) set += "GPVTG, ";
+        if (value == info._sentenceType.GPGGA) set += "GPZDA, ";
+      });
+      inf += `  sentences: Set {${set}}`;
+        
+      $("#text1").text(inf);
+
+      if (showMap) {
+        showMap = false;
+        const k = info.latitude;
+        const e = info.longitude;
+        let src=`https://www.google.com/maps?output=embed&iwloc=A&q=現在地@${k},${e}`;
+        $("#map").attr("src", src);
+        getAddr(k, e);
+      }
+      $("#quality").text(`[${info.gpsQuality}]${gps.gpsQuality2string(info.gpsQuality)}`);
+
+      var canvas = $('#canvas1')[0];
+      if (canvas.getContext) {
+        let width = $('#canvas1').prop("width");
+        let height = $('#canvas1').prop("height");
+        let context = canvas.getContext('2d');
+        context.save();
+
+        context.fillStyle = '#FFFFCC';
+        context.fillRect(0, 0, width, height);
+        context.strokeStyle = "gray";
+
+        context.beginPath();
+        context.textAlign = 'left';
+        context.textBaseline = 'top';
+        context.fillStyle = 'black';
+        context.fillText("SNR(Signal to Noise Ratio)[dB]", 2, 2, width);
+        context.stroke();
+
+        context.beginPath();
+        context.textAlign = 'center';
+        context.textBaseline = 'bottom';
+        context.fillStyle = 'black';
+        let newFont = "12" + context.font.substr(2);
+        context.font = newFont;
+        info.satelliteInfo.satellites.forEach(function(satellite, index) {
+          if (satellite.id) {
+            context.fillText(satellite.id, index*25+30, 118, width);
+          }
+        });
+        context.stroke();
+
+        context.beginPath();
+        context.textAlign = 'center';
+        context.textBaseline = 'bottom';
+        context.fillStyle = 'gray';
+        newFont = "9" + context.font.substr(2);
+        context.font = newFont;
+        info.satelliteInfo.satellites.forEach(function(satellite, index) {
+          if (!Number.isNaN(satellite.snr) && satellite.snr > 0) {
+            context.fillText(satellite.snr + "dB", index*25+30, 105-Math.round(satellite.snr*0.9)-2, width);
+          } else {
+            if (satellite.id) context.fillText("0dB", index*25+30, 105-2, width);
+          }
+        });
+        context.stroke();
+
+        info.satelliteInfo.satellites.forEach(function(satellite, index) {
+          if (!Number.isNaN(satellite.snr) && satellite.snr > 0) {
+            let w = 20, h = Math.round(satellite.snr*0.9);
+            let x = index*25+20, y = 105-h;
+            context.fillStyle =  satellite.inUse ? 'lime' : 'silver';
+            context.fillRect(x, y, w, h);
+          } else {
+            context.fillStyle = 'silver';
+            if (satellite.id) context.fillRect(index*25+20, 105-1, 20, 1);
+          }
+        });
+        context.restore();
+      }
+      canvas = $('#canvas2')[0];
+      if (canvas.getContext) {
+        let width = $('#canvas2').prop("width");
+        let height = $('#canvas2').prop("height");
+        let context = canvas.getContext('2d');
+
+        context.fillStyle = '#FFFFCC';
+        context.fillRect(0, 0, width, height);
+
+        context.beginPath();
+        context.textAlign = 'left';
+        context.textBaseline = 'top';
+        context.fillStyle = 'black';
+        context.fillText("Satellites in View", 2, 2, width);
+        context.stroke();
+
+        context.beginPath();
+        context.strokeStyle = "gray";
+        context.moveTo(0, height/2);
+        context.lineTo(width, height/2);
+        context.moveTo(width/2, 0);
+        context.lineTo(width/2, height);
+        context.stroke();
+
+        context.beginPath();
+        context.arc(width/2, height/2, (90- 0)*3.3/2, 0, Math.PI*2); //仰角0°
+        context.arc(width/2, height/2, (90-30)*3.3/2, 0, Math.PI*2); //仰角30°
+        context.arc(width/2, height/2, (90-60)*3.3/2, 0, Math.PI*2); //仰角60°
+        context.stroke();
+
+        info.satelliteInfo.satellites.forEach(function(satellite) {
+          const r = 20;
+          context.fillStyle = ((satellite.snr>0) && satellite.inUse) ? 'lime' : 'silver';
+          if (!Number.isNaN(satellite.elevation) && !Number.isNaN(satellite.azimuth)) {
+            context.beginPath();
+            let elevation = (90 - satellite.elevation) * 3.3/2;
+            let azimuth = (satellite.azimuth - 90) / 180 * Math.PI;
+            let x = Math.round(width/2 + elevation * Math.cos(azimuth));
+            let y = Math.round(height/2 + elevation * Math.sin(azimuth));
+            context.arc(x, y, r, 0, Math.PI*2);
+            context.fill();
+          }
+        });
+        context.textAlign = 'center';
+        context.textBaseline = 'middle';
+        context.fillStyle = 'black';
+        info.satelliteInfo.satellites.forEach(function(satellite) {
+          if (!Number.isNaN(satellite.elevation) && !Number.isNaN(satellite.azimuth)) {
+            const r = 20;
+            context.beginPath();
+            let elevation = (90 - satellite.elevation) * 3.3/2;
+            let azimuth = (satellite.azimuth - 90) / 180 * Math.PI;
+            let x = Math.round(width/2 + elevation * Math.cos(azimuth));
+            let y = Math.round(height/2 + elevation * Math.sin(azimuth));
+            context.fillText(satellite.id, x, y, width);
+            context.stroke();
+          }
+        });
+      }
+
+      var canvas = $('#canvas0')[0];
+      if (canvas.getContext) {
+        let width = $('#canvas0').prop("width");
+        let height = $('#canvas0').prop("height");
+        let context = canvas.getContext('2d');
+        context.fillStyle = '#FFFFCC';
+        context.fillRect(0, 0, width, height);
+        context.strokeStyle = "gray";
+
+        context.save();
+        context.beginPath();
+        context.arc(60, 60, 40, 0, Math.PI*2);
+        context.moveTo(60, 60);
+        context.lineTo(60, 15);
+
+        context.textAlign = 'center';
+        context.textBaseline = 'bottom';
+        context.fillStyle = 'red';
+        let newFont = "bold 12" + context.font.substr(2);
+        context.font = newFont;
+        context.fillText("N", 60, 15, width);
+        context.stroke();
+
+        context.beginPath();
+        context.strokeStyle = "red";
+        context.moveTo(60, 60);
+        let angle = (info.direction - 90) / 180 * Math.PI;
+        let x = Math.round(60 + 40 * Math.cos(angle));
+        let y = Math.round(60 + 40 * Math.sin(angle));
+        context.lineTo(x, y);
+        context.stroke();
+        context.beginPath();
+        context.fillStyle = "red";
+        context.arc(x, y, 2, 0, Math.PI*2);
+        context.fill();
+        context.restore();
+
+        context.beginPath();
+        context.textAlign = 'center';
+        context.textBaseline = 'bottom';
+        context.fillStyle = 'black';
+        let speed = (info.status == "A") ? info.speed + " km/h" : "no available";
+        context.fillText(speed, 60, 70, width);
+        context.stroke(); 
+      }
+      if (info.utc) $("#timestamp").text(localDatetime(info.utc) + " (JST)");
+    } else {
+      var inf = "gpsInfo\n" +
+      `  status: ${info.status} [${gps.status2string(info.status)}]\t// Active or Void\n`;
+      $("#text1").text(inf);
+    }
+    
+    setTimeout(mainLoop, 1000);
+  }
+
+
+  function clearText() {
+    for (let n=0; n<14; n++) {
+      let id = "#text" + n;
+      $(id).text("");
+    }
+    $("#addr").text("");
+  }
+  $("#clear").on(tapORclick, function(){
+    clearText();
+  });
+
+  obniz.switch.onchange = function(state) {
+    $('#print').text(state);
+    obniz.display.clear();
+    obniz.display.print(state);
+  }
+
+  function getAddr(lat, lng) {
+    let url = `http://maps.google.com/maps/api/geocode/json?latlng=${lat},${lng}&sensor=false&language=ja`;
+    $.get(url, function(data, status) {
+      let adr2;
+      if (data.results.length > 0) {
+      let adr = data.results[1].formatted_address;
+        adr2 = adr.substr(adr.lastIndexOf(" "));
+      } else {
+        adr2 = data.error_message + " : " + data.status;
+      }
+      $("#addr").text(adr2);
+    });
+  }
+
+  setInterval(function(){ showMap = true; }, 60*1000);
+  
+  setTimeout(mainLoop, 10);
+
+}
+
+</script>
+</body>
+</html>

--- a/parts/GPS/GYSFDMAXB/exsample.html
+++ b/parts/GPS/GYSFDMAXB/exsample.html
@@ -82,10 +82,8 @@ obniz.onconnect = async function () {
 
   var logging = false;
   var showMap = true;
-  Obniz.PartsRegistrate(GYSFDMAXB_2);
-  var gps = obniz.wired("GYSFDMAXB_2", { vcc:7, gnd:8, txd:9, rxd:10, Opps:11 });
-
-  var gpsInfo;
+//Obniz.PartsRegistrate(GYSFDMAXB);
+  var gps = obniz.wired("GYSFDMAXB", { vcc: 7, gnd: 8, txd: 9, rxd: 10, Opps: 11 });
 
   gps.start1pps(function() {
  // console.log("1pps received.");

--- a/parts/GPS/GYSFDMAXB/index.js
+++ b/parts/GPS/GYSFDMAXB/index.js
@@ -37,6 +37,22 @@ class GYSFDMAXB {
 
     this.on1pps = null;
     this.last1pps = 0;
+
+    this.gpsInfo = {};
+    this.gpsInfo._sentenceType = {
+      GPGGA: 0x0001,   // GGA - Global Positioning System Fix Data
+      GPGSA: 0x0002,   // GSA - GNSS DOP and active satellites
+      GPGSV: 0x0004,   // GSV - Satellites in view
+      GPRMC: 0x0008,   // RMC - Recommended minimum specific GNSS data
+      GPVTG: 0x0010,   // VTG - Track made good and ground speed
+      GPZDA: 0x0020,   // ZDA - Date & Time
+    };
+    this.gpsInfo.status = 'V';
+    this.gpsInfo.sentences = new Set(); // Set specifying sentence of MNEA from which data have been obtained
+    this.gpsInfo.satelliteInfo = {
+      satellites: [],
+      inView: 0,
+    };
   }
 
   start1pps(callback) {
@@ -75,6 +91,7 @@ class GYSFDMAXB {
     let n, utc, format;
     let sentence = this.readSentence();
     this.editedData.enable = false;
+    this.editedData.GPGSV = new Array(4);
     while (sentence.length > 0) {
       let part = sentence.split(',');
       if (sentence.slice(-4, -3) != ',') {
@@ -136,40 +153,175 @@ class GYSFDMAXB {
     return this.editedData;
   }
 
-  // NMEAの緯度経度を「度分秒(DMS)」の文字列に変換
-  static nmea2dms(v) {
-    let val = Number(v);
+  getGpsInfo(editedData) {
+    const NMEA_SATINSENTENCE = 4, NMEA_MAXSAT = 12;
+    editedData = editedData || this.getEditedData();
+    this.gpsInfo.status = 'V';
+    if (editedData.enable) {
+      if (editedData.GPGGA) {
+        const gga = editedData.GPGGA;
+        this.gpsInfo.gpsQuality = parseFloat(gga[6]); //Fix Quality: 0 = Invalid, 1 = GPS fix, 2 = DGPS fix
+        this.gpsInfo.hdop = parseFloat(gga[8]); //Horizontal Dilution of Precision (HDOP)
+        this.gpsInfo.altitude = parseFloat(gga[9]); //Antenna Altitude meters above mean sea level
+        const latitude = this.nmea2dd(parseFloat(gga[2]));
+        this.gpsInfo.latitude = ((gga[3] == 'N') ? latitude : -latitude);
+        const longitude = this.nmea2dd(parseFloat(gga[4]));
+        this.gpsInfo.longitude = ((gga[5] == 'E') ? longitude : -longitude);
+        this.gpsInfo.sentences.add(this.gpsInfo._sentenceType.GPGGA);
+      }
+      if (editedData.GPGSV) {
+        for (let n=0; n<editedData.GPGSV.length; n++)
+        if (editedData.GPGSV[n]) {
+          const gsv = editedData.GPGSV[n].map(v => parseFloat(v));
+          const pack_count = gsv[1], pack_index = gsv[2], sat_count = gsv[3];
+          if (pack_index > pack_count) continue;
+
+          this.gpsInfo.satelliteInfo.inView = sat_count;
+          var nsat = (pack_index - 1) * NMEA_SATINSENTENCE;
+          nsat = (nsat + NMEA_SATINSENTENCE > sat_count) ? sat_count - nsat : NMEA_SATINSENTENCE;
+
+          for (let isat = 0; isat < nsat; ++isat) {
+            const isi = (pack_index - 1) * NMEA_SATINSENTENCE + isat;
+            if (this.gpsInfo.satelliteInfo.satellites.length <= isi) {
+              this.gpsInfo.satelliteInfo.satellites.push({});
+            }
+            const isatn = isat * NMEA_SATINSENTENCE;
+            this.gpsInfo.satelliteInfo.satellites[isi] = {
+              id: gsv[isatn + 4],       // SV PRN number
+              elevation: gsv[isatn + 5],// Elevation in degrees, 90 maximum
+              azimuth: gsv[isatn + 6],  // Azimuth, degrees from true north, 000 to 359
+              snr: gsv[isatn + 7],      // SNR, 00-99 dB (null when not tracking)
+              inUse: false,
+            };
+          }
+        this.gpsInfo.sentences.add(this.gpsInfo._sentenceType.GPGSV);
+        }
+      }
+      if (editedData.GPGSA) {
+        const gsa = editedData.GPGSA;
+        var nuse = 0;
+        this.gpsInfo.fixMode = parseFloat(gsa[2]);  // Fix Mode: 1=Fix not available, 2=2D, 3=3D
+        this.gpsInfo.pdop = parseFloat(gsa[15]);    // PDOP: Position Dilution of Precision
+        this.gpsInfo.hdop = parseFloat(gsa[16]);    // HDOP: Horizontal Dilution of Precision
+        this.gpsInfo.vdop = parseFloat(gsa[17]);    // VDOP: Vertical Dilution of Position
+        for (let i = 0; i < NMEA_MAXSAT; ++i) {
+            for(let j = 0; j < this.gpsInfo.satelliteInfo.inView; ++j) {
+                if(this.gpsInfo.satelliteInfo.satellites[j] && (gsa[i + 3] == this.gpsInfo.satelliteInfo.satellites[j].id)) {
+                  this.gpsInfo.satelliteInfo.satellites[j].inUse = true;
+                  nuse++;
+                }
+            }
+        }
+        this.gpsInfo.satelliteInfo.inUse = nuse;
+        this.gpsInfo.sentences.add(this.gpsInfo._sentenceType.GPGSA);
+      }
+      if (editedData.GPRMC) {
+        const rmc = editedData.GPRMC;
+        this.gpsInfo.status = rmc[2]; // Status Active or Void
+        const latitude = this.nmea2dd(parseFloat(rmc[3]));
+        this.gpsInfo.latitude = ((rmc[4] == 'N') ? latitude : -latitude);
+        const longitude = this.nmea2dd(parseFloat(rmc[5]));
+        this.gpsInfo.longitude = ((rmc[6] == 'E') ? longitude : -longitude);
+        const NMEA_TUD_KNOTS = 1.852; // 1knot=1.852km/h
+        this.gpsInfo.speed = parseFloat(rmc[7]) * NMEA_TUD_KNOTS; //unit: km/h
+        this.gpsInfo.direction = rmc[8];
+        this.gpsInfo.sentences.add(this.gpsInfo._sentenceType.GPRMC);
+      }
+      if (editedData.GPVTG) {
+        const vtg = editedData.GPVTG;
+        this.gpsInfo.direction = parseFloat(vtg[1]);
+        this.gpsInfo.declination = parseFloat(vtg[3]);
+        this.gpsInfo.speed = parseFloat(vtg[7]);
+        this.gpsInfo.sentences.add(this.gpsInfo._sentenceType.GPVTG);
+      }
+      if (editedData.GPZDA) {
+        this.gpsInfo.utc = editedData.timestamp;
+        this.gpsInfo.sentences.add(this.gpsInfo._sentenceType.GPZDA);
+      }
+    }
+    return this.gpsInfo;
+  }
+//-------------------
+  get latitude() {
+    return this.nmea2dd(this._latitude);
+  }
+  get longitude() {
+    return this.nmea2dd(this._longitude);
+  }
+  _mneaTo(format, value) {
+    var result = this.nmea2dd(value);
+    if (typeof format == 'string') {
+      switch (format.toUpperCase()) {
+        case 'DMS':
+          result = this.nmea2dms(value);
+          break;
+        case 'DM':
+          result = this.nmea2dm(value);
+          break;
+        case 'S':
+          result = this.nmea2s(value);
+          break;
+        default:
+      }
+    }
+    return result;
+  }
+  latitudeTo(format) {
+    return this._mneaTo(format, this._latitude);
+  }
+  longitudeTo(format) {
+    return this._mneaTo(format, this._longitude);
+  }
+  status2string(status) {
+    status = status || this.status;
+    if (status == 'A') return 'Active';
+    if (status == 'V') return 'Void';
+    return status;
+  }
+  fixMode2string(fixMode) {
+    fixMode = fixMode || this.fixMode;
+    if (fixMode == 1) return 'Fix not available';
+    if (fixMode == 2) return '2D';
+    if (fixMode == 3) return '3D';
+    return fixMode;
+  }
+  gpsQuality2string(gpsQuality) {
+    gpsQuality = gpsQuality || this.gpsQuality;
+    if (gpsQuality == 0) return 'Invalid';
+    if (gpsQuality == 1) return 'GPS fix';
+    if (gpsQuality == 2) return 'DGPS fix';
+    return gpsQuality;
+  }
+
+//--- latitude/longitude MNEA format change to each unit
+  nmea2dms(val) {//NMEA format to DMS format string (999°99'99.9")
+    val = parseFloat(val);
     let d = Math.floor(val / 100);
     let m = Math.floor((val / 100.0 - d) * 100.0);
     let s = ((val / 100.0 - d) * 100.0 - m) * 60;
     return d + '°' + m + "'" + s.toFixed(1) + '"';
   }
-
-  // NMEAの緯度経度を「度分(DM)」の文字列に変換
-  static nmea2dm(v) {
-    let val = Number(v);
+  nmea2dm(val) {//NMEA format to DM format string (999°99.9999')
+    val = parseFloat(val);
     let d = Math.floor(val / 100.0);
     let m = (val / 100.0 - d) * 100.0;
     return d + '°' + m.toFixed(4) + "'";
   }
-
-  // NMEAの緯度経度を「度(DD)」の文字列に変換
-  static nmea2dd(v) {
-    let val = Number(v);
+  nmea2dd(val) {//NMEA format to DD format decimal (999.999999)
+    val = parseFloat(val);
     let d = Math.floor(val / 100.0);
     let m = Math.floor(((val / 100.0 - d) * 100.0) / 60);
     let s = (((val / 100.0 - d) * 100.0 - m) * 60) / (60 * 60);
-    return (d + m + s).toFixed(6);
+    return parseFloat((d + m + s).toFixed(6));
   }
-
-  // NMEAの緯度経度を「秒(S)」の数値に変換
-  static nmea2s(v) {
-    let val = Number(v);
+  nmea2s(val) {//NMEA format to S format decimal (99999.9999)
+    val = parseFloat(val);
     let d = Math.floor(val / 100.0);
     let m = Math.floor(((val / 100.0 - d) * 100.0) / 60);
     let s = (((val / 100.0 - d) * 100.0 - m) * 60) / (60 * 60);
     return (d + m + s) / (1.0 / 60.0 / 60.0);
   }
+
 }
 
 if (typeof module === 'object') {


### PR DESCRIPTION
先日ご連絡した通り、`GYSFDMAXB`クラスをアップデートしました。
staticメソッドの件と、GPSレシーバーとしてのデータを返すメソッド`getGpsInfo()`を追加しました。
下記の様なobjectを取得できます。<br>
本来なら`gpsInfo`を独立したclass定義としたいところですが、パーツライブラリはclassがそのまま見え無いので、GYSFDMAXBクラスの一部として内包しました。クラスを独立させる方法がありましたらご教授ください。<br>
また、今回のgetGpsInfo メソッドを使った場合のサンプルとして`exsample.html`も作りました。

```
gpsInfo
  utc: Sat Sep 08 2018 22:42:14 GMT+0900 (JST)
  status: A [Active]	// Active or Void
  fixMode: 3 [3D]	// 1:Fix not available, 2:2D, 3:3D
  gpsQuality: 2 [DGPS fix]	// 0:Invalid, 1:GPS fix, 2:DGPS fix
  latitude: 35.999999
  longitude: 139.999999
  pdop: 1.24	// PDOP: Position Dilution of Precision
  hdop: 0.97	// HDOP: Horizontal Dilution of Precision
  vdop: 0.77	// VDOP: Vertical Dilution of Position
  altitude: 57.4[M]
  declination: NaN	// Magnetic declination
  direction: 236.34
  speed: 0.02[km/h]
  satelliteInfo:
    inUse: 11
    inView: 15
    satellites: Array (15)
      [0]: {id: 194,	elevation: 87,	azimuth: 261,	snr: 31[dB],	inUse: true, }
      [1]: {id: 25,	elevation: 63,	azimuth: 179,	snr: 34[dB],	inUse: true, }
      [2]: {id: 12,	elevation: 59,	azimuth: 67,	snr: 20[dB],	inUse: true, }
      [3]: {id: 193,	elevation: 59,	azimuth: 210,	snr: 37[dB],	inUse: true, }
      [4]: {id: 10,	elevation: 55,	azimuth: 256,	snr: 40[dB],	inUse: true, }
      [5]: {id: 42,	elevation: 48,	azimuth: 170,	snr: 31[dB],	inUse: false, }
      [6]: {id: 20,	elevation: 43,	azimuth: 211,	snr: 35[dB],	inUse: true, }
      [7]: {id: 32,	elevation: 41,	azimuth: 315,	snr: 46[dB],	inUse: true, }
      [8]: {id: 24,	elevation: 35,	azimuth: 57,	snr: NaN[dB],	inUse: false, }
      [9]: {id: 15,	elevation: 25,	azimuth: 120,	snr: 23[dB],	inUse: true, }
      [10]: {id: 14,	elevation: 19,	azimuth: 307,	snr: 30[dB],	inUse: true, }
      [11]: {id: 195,	elevation: 18,	azimuth: 168,	snr: 28[dB],	inUse: true, }
      [12]: {id: 31,	elevation: 12,	azimuth: 260,	snr: 24[dB],	inUse: true, }
      [13]: {id: 19,	elevation: 5,	azimuth: 46,	snr: NaN[dB],	inUse: false, }
      [14]: {id: 29,	elevation: 1,	azimuth: 160,	snr: NaN[dB],	inUse: false, }
  sentences: Set {GPGGA, GPGSA, GPGSV, GPRMC, GPVTG, GPZDA, }
```

なお、`README-ja.md`は合わせてアップデートしてありますが、英語版は未対応です（英語が不得手なため）。申し訳ないですが、よろしくお願いします。
