### PR TITLE
Fix 7segment LED anode common bug.

### DIFF
--- a/parts/Display/7SegmentLED/index.js
+++ b/parts/Display/7SegmentLED/index.js
@@ -100,7 +100,7 @@ class _7SegmentLED {
         if (this.ios[i]) {
           let val = this.digits[data] & (1 << i) ? true : false;
           if (!this.isCathodeCommon) {
-            val = ~val;
+            val = !val;
           }
           this.ios[i].output(val);
         }


### PR DESCRIPTION
When handling the anode common case, 'print(data)' function uses bitwise operator '~'.
It should be operator '!'.