### PR TITLE
Fix type definitions of BME280.

### DIFF
--- a/parts/TemperatureSensor/i2c/BME280/index.d.ts
+++ b/parts/TemperatureSensor/i2c/BME280/index.d.ts
@@ -12,7 +12,7 @@ export interface BME280Options {
 
 export interface BME280 {
   applyCalibration(): Promise<void>;
-  setIIRStrength(value?: number);
+  setIIRStrength(value?: number): Promise<void>;
   getAllWait(): Promise<{ temperature: number; humidity: number; pressure: number }>;
   calcAltitude(pressure: number, seaPressure?: number): number;
 }


### PR DESCRIPTION
戻り値型の漏れを発見しました。
他の型定義ファイルも一通りざっくり確認してみましたが、ここだけだと思います。
よろしくお願い致します。