### PR TITLE
Add ArduCAM Plus option.

### DIFF
--- a/parts/Camera/ArduCAMMini/README-ja.md
+++ b/parts/Camera/ArduCAMMini/README-ja.md
@@ -3,12 +3,12 @@
 少ないピン数で利用できるカメラモジュールです。
 たくさんの解像度を選べる上に、jpegで画像を取り出すことが出来ます。
 
-同じArduCAMMiniでも種類がありますが、OV2640の2Mピクセルのカメラに対応しています。
+同じArduCAMMiniでも種類がありますが、OV2640搭載の2Mピクセルのカメラである、ArduCAM-Mini-2MPまたはArduCAM-Mini-2MP-Plusに対応しています。
 
 ![](./image.jpg)
 
 
-## wired(obniz,  {cs [, mosi, miso, sclk, gnd, vcc, sda, scl, spi, i2c, spi_drive, spi_frequency]} )
+## wired(obniz,  {cs [, mosi, miso, sclk, gnd, vcc, sda, scl, spi, i2c, spi_drive, spi_frequency, module_version]} )
 
 つながっているioを指定してオブジェクト化します。
 
@@ -40,6 +40,7 @@ i2c | `i2c object` | no | &nbsp; | configured i2c object
 spi | `spi object` | no | &nbsp; | configured spi object
 spi_frequency | `spi object` | no | 4Mhz | SPI通信がうまくいかない場合に周波数を下げる時に利用します
 spi_drive | `spi object` | no | `'3v'` | SPI通信がうまくいかない場合に駆動方法を変更する時に利用します
+module_version | `number` | no | 0 | ArduCAM-Mini-2MP-Plusを使用する場合は1を指定してください
 
 ピンだけを指定して以下のように設定することが出来ます。
 

--- a/parts/Camera/ArduCAMMini/README.md
+++ b/parts/Camera/ArduCAMMini/README.md
@@ -3,7 +3,7 @@
 ArduCAM Mini works with few pins.
 It takes image with many image resolutions and alos jpeg format.
 
-ArduCam Mini has many series of product. This library is only for OV2640 2M pixel ArduCam.
+ArduCam Mini has many series of product. This library is only for OV2640 2M pixel ArduCam, ArduCAM-Mini-2MP or ArduCAM-Mini-2MP-Plus.
 
 ![](./image.jpg)
 
@@ -41,6 +41,7 @@ i2c | `i2c object` | no | &nbsp; | configured i2c object
 spi | `spi object` | no | &nbsp; | configured spi object
 spi_frequency | `spi object` | no | 4Mhz | for unstable situation, change frequency of spi
 spi_drive | `spi object` | no | `'3v'` | for unstable situation, change drive method of spi
+module_version | `number` | no | 0 | Specify 1 when using ArduCAM-Mini-2MP-Plus
 
 Just specify connected io to configure.
 

--- a/parts/Camera/ArduCAMMini/index.d.ts
+++ b/parts/Camera/ArduCAMMini/index.d.ts
@@ -11,6 +11,7 @@ export interface ArduCAMMiniOptions {
   spi?: any; // TODO: spi object
   spi_drive?: any; // TODO: spi object
   spi_frequency?: any; // TODO: spi object
+  module_version?: number;
 }
 
 export type ArduCAMMiniMode = 'MCU2LCD' | 'CAM2LCD' | 'LCD2MCU';

--- a/parts/Camera/ArduCAMMini/index.js
+++ b/parts/Camera/ArduCAMMini/index.js
@@ -13,6 +13,7 @@ class ArduCAMMini {
       'i2c',
       'spi_frequency',
       'spi_drive',
+      'module_version'
     ];
     this.requiredKeys = ['cs'];
 
@@ -668,6 +669,7 @@ class ArduCAMMini {
 
     this.sensor_addr = 0x30; // i2c
 
+    this.params.module_version = this.params.module_version || 0;
     this.params.mode = this.params.mode || 'master';
     this.params.drive = this.params.spi_drive || '3v';
     this.params.frequency = this.params.spi_frequency || 4 * 1000 * 1000;
@@ -847,7 +849,10 @@ class ArduCAMMini {
     // start bust
     this.io_cs.output(false);
     this.spi.write([this.regs.BURST_FIFO_READ]);
-    this.spi.write([0xff]); // dummy read
+
+    if(this.params.module_version==0){
+      this.spi.write([0xff]); // dummy read
+    }
 
     let buf = [];
 


### PR DESCRIPTION
 `module_version` をオプション引数として追加し、これを1にすることでArduCAM-Mini-2MP-Plusでも使えるようにしました。
ArduCAMのソフトウェアアプリケーションノート5.5節 Burst Read Option に、この違いについて説明されています。
http://www.arducam.com/downloads/shields/ArduCAM_Camera_Shield_Software_Application_Note.pdf
