### PR TITLE
Feature/grove interface

### DIFF
--- a/dist/src/parts/Grove/Grove_Buzzer/index.js
+++ b/dist/src/parts/Grove/Grove_Buzzer/index.js
@@ -6,8 +6,8 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 class Grove_Buzzer {
     constructor() {
-        this.keys = ["signal", "gnd", "vcc"];
-        this.requiredKeys = ["signal"];
+        this.keys = ["signal", "gnd", "vcc", "grove"];
+        this.requiredKeys = [];
     }
     static info() {
         return {
@@ -15,10 +15,15 @@ class Grove_Buzzer {
         };
     }
     wired(obniz) {
-        this.obniz = obniz;
-        this.obniz.setVccGnd(this.params.vcc, this.params.gnd, "5v");
-        this.pwm = obniz.getFreePwm();
-        this.pwm.start({ io: this.params.signal });
+        if (this.params.grove) {
+            this.pwm = this.params.grove.getPwm();
+        }
+        else {
+            this.obniz = obniz;
+            obniz.setVccGnd(this.params.vcc, this.params.gnd, "5v");
+            this.pwm = obniz.getFreePwm();
+            this.pwm.start({ io: this.params.signal });
+        }
     }
     play(freq) {
         if (typeof freq !== "number") {

--- a/dist/src/parts/Grove/Grove_EarHeartRate/index.js
+++ b/dist/src/parts/Grove/Grove_EarHeartRate/index.js
@@ -13,8 +13,8 @@ class Grove_EarHeartRate {
         };
         this.interval = 5;
         this.duration = 2.5 * 1000;
-        this.keys = ["vcc", "gnd", "signal"];
-        this.requiredKeys = ["vcc", "gnd"];
+        this.keys = ["signal", "gnd", "vcc", "grove"];
+        this.requiredKeys = [];
     }
     static info() {
         return {
@@ -23,11 +23,18 @@ class Grove_EarHeartRate {
     }
     wired(obniz) {
         this.obniz = obniz;
-        obniz.setVccGnd(this.params.vcc, this.params.gnd, "5v");
+        if (this.params.grove) {
+            this.signal = this.params.grove.pin1;
+            this.params.grove.getDigital("5v");
+        }
+        else {
+            obniz.setVccGnd(this.params.vcc, this.params.gnd, "5v");
+            this.signal = this.params.signal;
+        }
     }
     start(callback) {
         this.obniz.logicAnalyzer.start({
-            io: this.params.signal,
+            io: this.signal,
             interval: this.interval,
             duration: this.duration,
         });

--- a/dist/src/parts/Grove/Grove_MP3/index.js
+++ b/dist/src/parts/Grove/Grove_MP3/index.js
@@ -6,8 +6,8 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 class Grove_MP3 {
     constructor() {
-        this.keys = ["vcc", "gnd", "mp3_rx", "mp3_tx"];
-        this.requiredKeys = ["mp3_rx", "mp3_tx"];
+        this.keys = ["vcc", "gnd", "mp3_rx", "mp3_tx", "grove"];
+        this.requiredKeys = [];
         this.ioKeys = this.keys;
         this.displayName = "MP3";
         this.displayIoNames = { mp3_rx: "MP3Rx", mp3_tx: "MP3Tx" };
@@ -19,17 +19,22 @@ class Grove_MP3 {
     }
     wired(obniz) {
         this.obniz = obniz;
-        obniz.setVccGnd(this.params.vcc, this.params.gnd, "5v");
-        this.my_tx = this.params.mp3_rx;
-        this.my_rx = this.params.mp3_tx;
-        this.uart = this.obniz.getFreeUart();
+        if (this.params.grove) {
+            this.uart = this.params.grove.getUart(9600, "5v");
+        }
+        else {
+            obniz.setVccGnd(this.params.vcc, this.params.gnd, "5v");
+            this.my_tx = this.params.mp3_rx;
+            this.my_rx = this.params.mp3_tx;
+            this.uart = this.obniz.getFreeUart();
+            this.uart.start({
+                tx: this.my_tx,
+                rx: this.my_rx,
+                baud: 9600,
+            });
+        }
     }
     async initWait(strage) {
-        this.uart.start({
-            tx: this.my_tx,
-            rx: this.my_rx,
-            baud: 9600,
-        });
         await this.obniz.wait(100);
         this.uartSend(0x0c, 0);
         await this.obniz.wait(500);

--- a/obniz.js
+++ b/obniz.js
@@ -37679,8 +37679,8 @@ exports.default = Grove_Button;
 Object.defineProperty(exports, "__esModule", { value: true });
 class Grove_Buzzer {
     constructor() {
-        this.keys = ["signal", "gnd", "vcc"];
-        this.requiredKeys = ["signal"];
+        this.keys = ["signal", "gnd", "vcc", "grove"];
+        this.requiredKeys = [];
     }
     static info() {
         return {
@@ -37688,10 +37688,15 @@ class Grove_Buzzer {
         };
     }
     wired(obniz) {
-        this.obniz = obniz;
-        this.obniz.setVccGnd(this.params.vcc, this.params.gnd, "5v");
-        this.pwm = obniz.getFreePwm();
-        this.pwm.start({ io: this.params.signal });
+        if (this.params.grove) {
+            this.pwm = this.params.grove.getPwm();
+        }
+        else {
+            this.obniz = obniz;
+            obniz.setVccGnd(this.params.vcc, this.params.gnd, "5v");
+            this.pwm = obniz.getFreePwm();
+            this.pwm.start({ io: this.params.signal });
+        }
     }
     play(freq) {
         if (typeof freq !== "number") {
@@ -37833,8 +37838,8 @@ class Grove_EarHeartRate {
         };
         this.interval = 5;
         this.duration = 2.5 * 1000;
-        this.keys = ["vcc", "gnd", "signal"];
-        this.requiredKeys = ["vcc", "gnd"];
+        this.keys = ["signal", "gnd", "vcc", "grove"];
+        this.requiredKeys = [];
     }
     static info() {
         return {
@@ -37843,11 +37848,18 @@ class Grove_EarHeartRate {
     }
     wired(obniz) {
         this.obniz = obniz;
-        obniz.setVccGnd(this.params.vcc, this.params.gnd, "5v");
+        if (this.params.grove) {
+            this.signal = this.params.grove.pin1;
+            this.params.grove.getDigital("5v");
+        }
+        else {
+            obniz.setVccGnd(this.params.vcc, this.params.gnd, "5v");
+            this.signal = this.params.signal;
+        }
     }
     start(callback) {
         this.obniz.logicAnalyzer.start({
-            io: this.params.signal,
+            io: this.signal,
             interval: this.interval,
             duration: this.duration,
         });
@@ -38336,8 +38348,8 @@ exports.default = Grove_LightSensor;
 Object.defineProperty(exports, "__esModule", { value: true });
 class Grove_MP3 {
     constructor() {
-        this.keys = ["vcc", "gnd", "mp3_rx", "mp3_tx"];
-        this.requiredKeys = ["mp3_rx", "mp3_tx"];
+        this.keys = ["vcc", "gnd", "mp3_rx", "mp3_tx", "grove"];
+        this.requiredKeys = [];
         this.ioKeys = this.keys;
         this.displayName = "MP3";
         this.displayIoNames = { mp3_rx: "MP3Rx", mp3_tx: "MP3Tx" };
@@ -38349,17 +38361,22 @@ class Grove_MP3 {
     }
     wired(obniz) {
         this.obniz = obniz;
-        obniz.setVccGnd(this.params.vcc, this.params.gnd, "5v");
-        this.my_tx = this.params.mp3_rx;
-        this.my_rx = this.params.mp3_tx;
-        this.uart = this.obniz.getFreeUart();
+        if (this.params.grove) {
+            this.uart = this.params.grove.getUart(9600, "5v");
+        }
+        else {
+            obniz.setVccGnd(this.params.vcc, this.params.gnd, "5v");
+            this.my_tx = this.params.mp3_rx;
+            this.my_rx = this.params.mp3_tx;
+            this.uart = this.obniz.getFreeUart();
+            this.uart.start({
+                tx: this.my_tx,
+                rx: this.my_rx,
+                baud: 9600,
+            });
+        }
     }
     async initWait(strage) {
-        this.uart.start({
-            tx: this.my_tx,
-            rx: this.my_rx,
-            baud: 9600,
-        });
         await this.obniz.wait(100);
         this.uartSend(0x0c, 0);
         await this.obniz.wait(500);

--- a/src/parts/Grove/Grove_3AxisAccelerometer/README-ja.md
+++ b/src/parts/Grove/Grove_3AxisAccelerometer/README-ja.md
@@ -4,7 +4,7 @@ Grove 3軸加速度センサモジュール[Grove - 3 Axis Digital Accelerometer
 
 ![](image.jpg)
 
-## wired(scl, sda {, vcc, gnd})
+## wired(scl, sda {, vcc, gnd, grove})
 
 obniz Boardに3軸加速度センサを接続します。
 次のように接続を行います。
@@ -16,10 +16,18 @@ obniz Boardに3軸加速度センサを接続します。
 | vcc | - | vcc |
 | gnd | - | gnd |
 
+
 ```javascript
 // Javascript Example
 var accelMeter = obniz.wired("Grove_3AxisAccelerometer", { scl:0, sda:1, vcc:2, gnd:3 });
 ```
+  
+groveを持つデバイスでは、パラメータに{grove: obniz.grove0}を指定することで接続できます。
+```javascript
+// Javascript Example
+var accelMeter = obniz.wired("Grove_3AxisAccelerometer", {grove: obniz.grove0});
+```
+
 
 ## [await] getWait()
 

--- a/src/parts/Grove/Grove_3AxisAccelerometer/README.md
+++ b/src/parts/Grove/Grove_3AxisAccelerometer/README.md
@@ -4,7 +4,7 @@ Library for Grove 3-axis accelerometer module[Grove - 3 Axis Digital Acceleromet
 
 ![](image.jpg)
 
-## wired(scl, sda {, vcc, gnd})
+## wired(scl, sda {, vcc, gnd, grove})
 Connect pins to an obniz Board.
 
 | grove | cable | obniz |
@@ -17,6 +17,12 @@ Connect pins to an obniz Board.
 ```javascript
 // Javascript Example
 var accelMeter = obniz.wired("Grove_3AxisAccelerometer", { scl:0, sda:1, vcc:2, gnd:3 });
+```
+
+If the device has a grove interface, it can be connected with just the parameter {grove: obniz.grove0}.
+```javascript
+// Javascript Example
+var accelMeter = obniz.wired("Grove_3AxisAccelerometer", {grove: obniz.grove0});
 ```
 
 ## [await] getWait()

--- a/src/parts/Grove/Grove_Button/README-ja.md
+++ b/src/parts/Grove/Grove_Button/README-ja.md
@@ -22,6 +22,7 @@ button.onchange = function(voltage) {
 }
 ```
 
+groveを持つデバイスでは、パラメータに{grove: obniz.grove0}を指定することで接続できます。
 ```Javascript
 // Javascript Example
 var button = obniz.wired("Grove_Button", {grove: obniz.grove0});

--- a/src/parts/Grove/Grove_Button/README.md
+++ b/src/parts/Grove/Grove_Button/README.md
@@ -21,7 +21,7 @@ button.onchange = function(voltage) {
   console.log(voltage);
 }
 ```
-
+If the device has a grove interface, it can be connected with just the parameter {grove: obniz.grove0}.
 ```Javascript
 // Javascript Example
 var button = obniz.wired("Grove_Button", {grove: obniz.grove0});

--- a/src/parts/Grove/Grove_Buzzer/README-ja.md
+++ b/src/parts/Grove/Grove_Buzzer/README-ja.md
@@ -4,7 +4,7 @@ Groveコネクタで利用できるブザーです。指定した高さの音を
 
 ![](image.jpg)
 
-## wired(obniz,  { signal [, vcc, gnd]});
+## wired(obniz,  { signal [, vcc, gnd, grove]});
 
 
 name | type | required | default | description
@@ -12,14 +12,20 @@ name | type | required | default | description
 signal | `number(obniz Board io)` | yes |  &nbsp; | signal 出力端子(4 pin of Grove)
 vcc | `number(obniz Board io)` | no |  &nbsp; | VCC端子(2 pin of Grove)
 gnd | `number(obniz Board io)` | no |  &nbsp; | GND端子(0 pin of Grove)
+grove | `object` | no | &nbsp;  | 接続するデバイスにgroveがある場合に利用できます
 
+  
 
 ```Javascript
 // Javascript Example
 var speaker = obniz.wired("Grove_Buzzer", {gnd:0, vcc:1, signal: 3});
-speaker.play(1000) // 1000 Hz
 ```
-
+  
+groveを持つデバイスでは、パラメータに{grove: obniz.grove0}を指定することで接続できます。
+```Javascript
+// Javascript Example
+var speaker = obniz.wired("Grove_Buzzer", {grove: obniz.grove0});
+```
 ## play(frequency)
 
 スピーカーから指定した周波数の音を鳴らします

--- a/src/parts/Grove/Grove_Buzzer/README.md
+++ b/src/parts/Grove/Grove_Buzzer/README.md
@@ -4,7 +4,7 @@ Grove connectable buzzer. It make a specified sound.
 
 ![](image.jpg)
 
-## wired(obniz,  { signal [, vcc, gnd]});
+## wired(obniz,  { signal [, vcc, gnd, grove]});
 
 
 name | type | required | default | description
@@ -12,13 +12,19 @@ name | type | required | default | description
 signal | `number(obniz Board io)` | yes |  &nbsp; | signal output pin(4 pin of Grove)
 vcc | `number(obniz Board io)` | no |  &nbsp; | VCC(2 pin of Grove)
 gnd | `number(obniz Board io)` | no |  &nbsp; | GND(0 pin of Grove)
+grove | `object` | no | &nbsp;  | grove interface object if a device has
 
 
 ```Javascript
 // Javascript Example
 var speaker = obniz.wired("Grove_Buzzer", {gnd:0, vcc:1, signal: 3});
-speaker.play(1000) // 1000 Hz
 ```
+
+If the device has a grove interface, it can be connected with just the parameter {grove: obniz.grove0}.
+```Javascript
+// Javascript Example
+var speaker = obniz.wired("Grove_Buzzer", {grove: obniz.grove0});
+``` 
 
 ## play(frequency)
 

--- a/src/parts/Grove/Grove_Buzzer/index.ts
+++ b/src/parts/Grove/Grove_Buzzer/index.ts
@@ -4,14 +4,21 @@
  */
 
 import Obniz from "../../../obniz";
+import PeripheralGrove from "../../../obniz/libs/io_peripherals/grove";
 import PeripheralPWM from "../../../obniz/libs/io_peripherals/pwm";
 import ObnizPartsInterface, { ObnizPartsInfo } from "../../../obniz/ObnizPartsInterface";
 
-export interface Grove_BuzzerOptions {
+export interface Grove_BuzzerOptionsA {
   signal: number;
   gnd?: number;
   vcc?: number;
 }
+
+interface Grove_BuzzerOptionsB {
+  grove: PeripheralGrove;
+}
+
+export type Grove_BuzzerOptions = Grove_BuzzerOptionsA | Grove_BuzzerOptionsB;
 
 export default class Grove_Buzzer implements ObnizPartsInterface {
   public static info(): ObnizPartsInfo {
@@ -29,15 +36,19 @@ export default class Grove_Buzzer implements ObnizPartsInterface {
   private pwm!: PeripheralPWM;
 
   constructor() {
-    this.keys = ["signal", "gnd", "vcc"];
-    this.requiredKeys = ["signal"];
+    this.keys = ["signal", "gnd", "vcc", "grove"];
+    this.requiredKeys = [];
   }
 
   public wired(obniz: Obniz) {
-    this.obniz = obniz;
-    this.obniz.setVccGnd(this.params.vcc, this.params.gnd, "5v");
-    this.pwm = obniz.getFreePwm();
-    this.pwm.start({ io: this.params.signal });
+    if (this.params.grove) {
+      this.pwm = this.params.grove.getPwm();
+    } else {
+      this.obniz = obniz;
+      obniz.setVccGnd(this.params.vcc, this.params.gnd, "5v");
+      this.pwm = obniz.getFreePwm();
+      this.pwm.start({ io: this.params.signal });
+    }
   }
 
   public play(freq: number) {

--- a/src/parts/Grove/Grove_DistanceSensor/README-ja.md
+++ b/src/parts/Grove/Grove_DistanceSensor/README-ja.md
@@ -17,7 +17,12 @@ gnd | `number(obniz Board io)` | no |  &nbsp; | モジュールの場合はgnd, 
 signal | `number(obniz Board io)` | no |  &nbsp; | 	signal 出力端子
 grove | `object` | no | &nbsp;  | 接続するデバイスにgroveがある場合に利用できます
 
+```javascript
+// Javascript Example
+let sensor = obniz.wired("Grove_DistanceSensor", {vcc:0, gnd:1, signal:2})
+```
 
+groveを持つデバイスでは、パラメータに{grove: obniz.grove0}を指定することで接続できます。
 ```javascript
 // Javascript Example
 let sensor = obniz.wired("Grove_DistanceSensor", {grove: obniz.grove0});

--- a/src/parts/Grove/Grove_DistanceSensor/README.md
+++ b/src/parts/Grove/Grove_DistanceSensor/README.md
@@ -17,7 +17,12 @@ gnd | `number(obniz Board io)` | no |  &nbsp; | Power Supply
 signal | `number(obniz Board io)` | no |  &nbsp; | signal output pin
 grove | `object` | no | &nbsp;  | grove interface object if a device has
 
+```javascript
+// Javascript Example
+let sensor = obniz.wired("Grove_DistanceSensor", {vcc:0, gnd:1, signal:2});
+```
 
+If the device has a grove interface, it can be connected with just the parameter {grove: obniz.grove0}.
 ```javascript
 // Javascript Example
 let sensor = obniz.wired("Grove_DistanceSensor", {grove: obniz.grove0});

--- a/src/parts/Grove/Grove_EARTH/README-ja.md
+++ b/src/parts/Grove/Grove_EARTH/README-ja.md
@@ -19,6 +19,16 @@ grove | `object` | no | &nbsp;  | 接続するデバイスにgroveがある場�
 白線、黄線、赤線、黒線がそれぞれaout、dout、vcc、gndに対応しています。
 
 ```javascript
+obniz.onconnect = async function() {
+  var earth = obniz.wired("Grove_EARTH", {aout: 0, dout: 1, vcc: 2, gnd: 3});
+  earth.onchange = (val) => {
+    console.log(val)
+  }
+}
+```
+  
+groveを持つデバイスでは、パラメータに{grove: obniz.grove0}を指定することで接続できます。
+```javascript
 var obniz = new Obniz.M5StickC("OBNIZ_ID_HERE");
 obniz.onconnect = async function() {
   var earth = obniz.wired("Grove_EARTH", { grove: obniz.grove0 });

--- a/src/parts/Grove/Grove_EARTH/README.md
+++ b/src/parts/Grove/Grove_EARTH/README.md
@@ -7,7 +7,7 @@ It detect moisture level in soil.
 It has both analog and digital outputs.
 
 
-## wired(obniz, { aout, dout, vcc, gnd })
+## wired(obniz, { aout, dout, vcc, gnd, grove })
 connect EARTH UNIT to the obniz Device.  
 
 name | type | required | default | description
@@ -18,6 +18,16 @@ dout | `number(obniz Board io)` | no |  &nbsp; | digital out
 aout | `number(obniz Board io)` | no | &nbsp;  | analog out
 grove | `object` | no | &nbsp;  | grove property when device has a grove interface
 
+```javascript
+obniz.onconnect = async function() {
+  var earth = obniz.wired("Grove_EARTH", {aout: 0, dout: 1, vcc: 2, gnd: 3});
+  earth.onchange = (val) => {
+    console.log(val)
+  }
+}
+```  
+  
+If the device has a grove interface, it can be connected with just the parameter {grove: obniz.grove0}.
 ```javascript
 // JavaScript Example
 var obniz = new Obniz.M5StickC("OBNIZ_ID_HERE");

--- a/src/parts/Grove/Grove_EarHeartRate/README-ja.md
+++ b/src/parts/Grove/Grove_EarHeartRate/README-ja.md
@@ -10,7 +10,7 @@ Stores
 [https://www.switch-science.com/catalog/2526/](https://www.switch-science.com/catalog/2526/)
 
 
-## wired(obniz, {gnd, vcc, signal})
+## wired(obniz, {gnd, vcc, signal, grove})
 センサーと接続します。
 センサーからはGroveケーブルで３本のケーブルがでています。
 黒がGND,赤がVCC、黄色がsignalです。
@@ -23,6 +23,12 @@ var heartrate = obniz.wired("Grove_EarHeartRate", {gnd: 0, vcc: 1, signal: 2});
 heartrate.start(function(rate){
   console.log(rate);
 })
+```
+
+groveを持つデバイスでは、パラメータに{grove: obniz.grove0}を指定することで接続できます。
+```Javascript
+// Javascript Example
+var heartrate = obniz.wired("Grove_EarHeartRate", {grove: obniz.grove0});
 ```
 
 ## start(callback(heartrate))

--- a/src/parts/Grove/Grove_EarHeartRate/README.md
+++ b/src/parts/Grove/Grove_EarHeartRate/README.md
@@ -10,7 +10,7 @@ Stores
 [https://www.switch-science.com/catalog/2526/](https://www.switch-science.com/catalog/2526/)
 
 
-## wired(obniz, {gnd, vcc, signal})
+## wired(obniz, {gnd, vcc, signal, grove})
 Connect Grove cables.
 Black: GND, Red: VCC, Yellow: Signal.
 
@@ -20,6 +20,12 @@ var heartrate = obniz.wired("Grove_EarHeartRate", {gnd: 0, vcc: 1, signal: 2});
 heartrate.start(function(rate){
   console.log(rate);
 })
+```
+
+If the device has a grove interface, it can be connected with just the parameter {grove: obniz.grove0}.
+```Javascript
+// Javascript Example
+var heartrate = obniz.wired("Grove_EarHeartRate", {grove: obniz.grove0});
 ```
 
 ## start(callback(heartrate))

--- a/src/parts/Grove/Grove_EarHeartRate/index.ts
+++ b/src/parts/Grove/Grove_EarHeartRate/index.ts
@@ -4,13 +4,20 @@
  */
 
 import Obniz from "../../../obniz";
+import PeripheralGrove from "../../../obniz/libs/io_peripherals/grove";
 import ObnizPartsInterface, { ObnizPartsInfo } from "../../../obniz/ObnizPartsInterface";
 
-export interface Grove_EarHeartRateOptions {
-  gnd: number;
-  vcc: number;
-  signal?: number;
+export interface Grove_EarHeartrateOptionsA {
+  signal: number;
+  gnd?: number;
+  vcc?: number;
 }
+
+interface Grove_EarHeartrateOptionsB {
+  grove: PeripheralGrove;
+}
+
+export type Grove_EarHeartrateOptions = Grove_EarHeartrateOptionsA | Grove_EarHeartrateOptionsB;
 
 export default class Grove_EarHeartRate implements ObnizPartsInterface {
   public static info(): ObnizPartsInfo {
@@ -27,6 +34,7 @@ export default class Grove_EarHeartRate implements ObnizPartsInterface {
     signal: "signal",
   };
   public params: any;
+  public signal: any;
 
   public interval = 5;
   public duration = 2.5 * 1000;
@@ -34,18 +42,24 @@ export default class Grove_EarHeartRate implements ObnizPartsInterface {
   protected obniz!: Obniz;
 
   constructor() {
-    this.keys = ["vcc", "gnd", "signal"];
-    this.requiredKeys = ["vcc", "gnd"];
+    this.keys = ["signal", "gnd", "vcc", "grove"];
+    this.requiredKeys = [];
   }
 
   public wired(obniz: Obniz) {
     this.obniz = obniz;
-    obniz.setVccGnd(this.params.vcc, this.params.gnd, "5v");
+    if (this.params.grove) {
+      this.signal = this.params.grove.pin1;
+      this.params.grove.getDigital("5v");
+    } else {
+      obniz.setVccGnd(this.params.vcc, this.params.gnd, "5v");
+      this.signal = this.params.signal;
+    }
   }
 
   public start(callback: (rate: number) => void) {
     this.obniz.logicAnalyzer!.start({
-      io: this.params.signal as number,
+      io: this.signal as number,
       interval: this.interval as number,
       duration: this.duration as number,
     });

--- a/src/parts/Grove/Grove_EarHeartRate/index.ts
+++ b/src/parts/Grove/Grove_EarHeartRate/index.ts
@@ -7,17 +7,17 @@ import Obniz from "../../../obniz";
 import PeripheralGrove from "../../../obniz/libs/io_peripherals/grove";
 import ObnizPartsInterface, { ObnizPartsInfo } from "../../../obniz/ObnizPartsInterface";
 
-export interface Grove_EarHeartrateOptionsA {
+export interface Grove_EarHeartRateOptionsA {
   signal: number;
   gnd?: number;
   vcc?: number;
 }
 
-interface Grove_EarHeartrateOptionsB {
+interface Grove_EarHeartRateOptionsB {
   grove: PeripheralGrove;
 }
 
-export type Grove_EarHeartrateOptions = Grove_EarHeartrateOptionsA | Grove_EarHeartrateOptionsB;
+export type Grove_EarHeartRateOptions = Grove_EarHeartRateOptionsA | Grove_EarHeartRateOptionsB;
 
 export default class Grove_EarHeartRate implements ObnizPartsInterface {
   public static info(): ObnizPartsInfo {

--- a/src/parts/Grove/Grove_GPS/README-ja.md
+++ b/src/parts/Grove/Grove_GPS/README-ja.md
@@ -36,7 +36,7 @@ Grove GPSモジュール[(Grove - GPS)](https://www.seeedstudio.com/Grove-GPS-p-
 ```
 
 
-## wired(rx, tx {, vcc, gnd})
+## wired(rx, tx {, vcc, gnd, grove})
 
 obniz BoardにGPSモジュールを接続します。
 次のように接続を行います。
@@ -55,6 +55,13 @@ obniz BoardにGPSモジュールを接続します。
 // Javascript Example
 let gps = obniz.wired("Grove_GPS", { rx:0, tx:1, vcc:2, gnd:3 });
 ```
+
+groveを持つデバイスでは、パラメータに{grove: obniz.grove0}を指定することで接続できます。
+```Javascript
+// Javascript Example
+let gps = obniz.wired("Grove_GPS", {grove: obniz.grove0});
+``` 
+
 
 ## readSentence()
 

--- a/src/parts/Grove/Grove_GPS/README.md
+++ b/src/parts/Grove/Grove_GPS/README.md
@@ -36,7 +36,7 @@ Library for Grove GPS Module [Grove - GPS](https://www.seeedstudio.com/Grove-GPS
 </html>
 ```
 
-## wired(tx, rx {, vcc, gnd})
+## wired(tx, rx {, vcc, gnd, grove})
 
 Connect tx, rx, vcc, gnd to an obniz Board.
 
@@ -56,6 +56,12 @@ And specify the pins on program.
 // Javascript Example
 let gps = obniz.wired("Grove_GPS", { rx:0, tx:1, vcc:2, gnd:3 });
 ```
+
+If the device has a grove interface, it can be connected with just the parameter {grove: obniz.grove0}.
+```Javascript
+// Javascript Example
+let gps = obniz.wired("Grove_GPS", {grove: obniz.grove0});
+``` 
 
 Functions are common with [GYSFDMAXB Library](https://obniz.io/ja/sdk/parts/GYSFDMAXB/README.md) apart from start1pps function.
 The following is common functions.

--- a/src/parts/Grove/Grove_JoyStick/README-ja.md
+++ b/src/parts/Grove/Grove_JoyStick/README-ja.md
@@ -18,15 +18,16 @@ i2c | `object` | no | &nbsp;  | obnizのi2cオブジェクトです
 grove | `object` | no | &nbsp;  | 接続するデバイスにgroveがある場合に利用できます
 
 ```javascript
+var joystick = obniz.wired("Grove_JoyStick", { scl:0, sda:1, vcc:2, gnd:3 });
+```
+
+
+groveを持つデバイスでは、パラメータに{grove: obniz.grove0}を指定することで接続できます。
+
+```javascript
 var obniz = new Obniz.M5StickC("OBNIZ_ID_HERE");
 obniz.onconnect = async function() {
   var joystick = obniz.wired("Grove_JoyStick", { grove: obniz.grove0 });
-  while(true) {
-    var x = await joystick.getXWait()
-    var y = await joystick.getYWait()
-    console.log(`${x}-${y}`);
-    await obniz.wait(1);
-  }
 }
 ```
 

--- a/src/parts/Grove/Grove_JoyStick/README.md
+++ b/src/parts/Grove/Grove_JoyStick/README.md
@@ -20,15 +20,14 @@ i2c | `object` | no | &nbsp;  | obniz i2c object
 grove | `object` | no | &nbsp;  | grove interface object if a device has
 
 ```javascript
+var joystick = obniz.wired("Grove_JoyStick", { scl:0, sda:1, vcc:2, gnd:3 });
+```
+
+If the device has a grove interface, it can be connected with just the parameter {grove: obniz.grove0}.
+```javascript
 var obniz = new Obniz.M5StickC("OBNIZ_ID_HERE");
 obniz.onconnect = async function() {
   var joystick = obniz.wired("Grove_JoyStick", { grove: obniz.grove0 });
-  while(true) {
-    var x = await joystick.getXWait()
-    var y = await joystick.getYWait()
-    console.log(`${x}-${y}`);
-    await obniz.wait(1);
-  }
 }
 ```
 

--- a/src/parts/Grove/Grove_LightSensor/README-ja.md
+++ b/src/parts/Grove/Grove_LightSensor/README-ja.md
@@ -18,6 +18,12 @@ grove | `object` | no | &nbsp;  | 接続するデバイスにgroveがある場�
 
 ```Javascript
 // Javascript Example
+let sensor = obniz.wired("Grove_LightSensor", {gnd:0, vcc:1, signal: 3});
+```
+
+groveを持つデバイスでは、パラメータに{grove: obniz.grove0}を指定することで接続できます。
+```Javascript
+// Javascript Example
 let sensor = obniz.wired("Grove_LightSensor", {grove: obniz.grove0});
 ```
 

--- a/src/parts/Grove/Grove_LightSensor/README.md
+++ b/src/parts/Grove/Grove_LightSensor/README.md
@@ -17,7 +17,12 @@ gnd | `number(obniz Board io)` | no |  &nbsp; | Power Supply
 signal | `number(obniz Board iov)` | no |  &nbsp; | signal output pin
 grove | `object` | no | &nbsp;  | grove interface object if a device has
 
-
+```Javascript
+// Javascript Example
+let sensor = obniz.wired("Grove_LightSensor", {gnd:0, vcc:1, signal: 3});
+```
+  
+If the device has a grove interface, it can be connected with just the parameter {grove: obniz.grove0}.
 ```Javascript
 // Javascript Example
 let sensor = obniz.wired("Grove_LightSensor", {grove: obniz.grove0});

--- a/src/parts/Grove/Grove_MP3/README-ja.md
+++ b/src/parts/Grove/Grove_MP3/README-ja.md
@@ -59,7 +59,8 @@ Groveケーブルの場合以下のようになります。
 var mp3 = obniz.wired("Grove_MP3", {gnd:0, vcc:1, mp3_rx:2, mp3_tx:3});
 ```
   
-groveを持つデバイスでは、パラメータに{grove: obniz.grove0}を指定することで接続できます。
+groveを持つデバイスでは、パラメータに{grove: obniz.grove0}を指定することで接続できます。  
+※ M5Stack,M5StickCでは動作電圧が足りず、正しく動作しない可能性があります。
 ```Javascript
 // Javascript Example
 var mp3 = obniz.wired("Grove_MP3", {grove: obniz.grove0});

--- a/src/parts/Grove/Grove_MP3/README-ja.md
+++ b/src/parts/Grove/Grove_MP3/README-ja.md
@@ -43,7 +43,7 @@ MP3ファイル
 一つのフォルダ内のファイルは255個(01~255)までです。
 例: /01/001abc.mp3, /02/001cdf.mp3
 
-## wired(obniz, {vcc, gnd, mp3_rx, mp3_tx})
+## wired(obniz, {vcc, gnd, mp3_rx, mp3_tx, grove})
 モジュールと接続します。
 Groveケーブルの場合以下のようになります。
 
@@ -57,7 +57,12 @@ Groveケーブルの場合以下のようになります。
 ```Javascript
 // Javascript Example
 var mp3 = obniz.wired("Grove_MP3", {gnd:0, vcc:1, mp3_rx:2, mp3_tx:3});
-// Groveケーブルの場合はobniz BoardのIO_0に黒,IO_1に赤,IO_2に白,IO_3に黄色を接続してください。
+```
+  
+groveを持つデバイスでは、パラメータに{grove: obniz.grove0}を指定することで接続できます。
+```Javascript
+// Javascript Example
+var mp3 = obniz.wired("Grove_MP3", {grove: obniz.grove0});
 ```
 
 ## [await] initWait()

--- a/src/parts/Grove/Grove_MP3/README.md
+++ b/src/parts/Grove/Grove_MP3/README.md
@@ -42,7 +42,7 @@ Filenames under this kind of folder should be 3 digits from 001.
 
 One folder can contain files up to 255.
 
-## wired(obniz, {gnd, vcc, mp3_rx, mp3_tx})
+## wired(obniz, {gnd, vcc, mp3_rx, mp3_tx, grove})
 
 Connect to a module.
 If you are using Grove cable, 
@@ -57,6 +57,12 @@ If you are using Grove cable,
 ```Javascript
 // Javascript Example
 var mp3 = obniz.wired("Grove_MP3", {gnd:0, vcc:1, mp3_rx:2, mp3_tx:3});
+```
+  
+If the device has a grove interface, it can be connected with just the parameter {grove: obniz.grove0}.
+```Javascript
+// Javascript Example
+var mp3 = obniz.wired("Grove_MP3", {grove: obniz.grove0});
 ```
 
 ## [await] initWait()

--- a/src/parts/Grove/Grove_PressureSensor/README-ja.md
+++ b/src/parts/Grove/Grove_PressureSensor/README-ja.md
@@ -15,6 +15,12 @@ gnd | `number(obniz Board io)` | no |  &nbsp; | モジュールの場合はgnd, 
 output | `number(obniz Board io)` | no |  &nbsp; | output 出力端子
 grove | `object` | no | &nbsp;  | 接続するデバイスにgroveがある場合に利用できます
 
+```Javascript
+// Javascript Example
+let sensor = obniz.wired("Grove_PressureSensor", {gnd:0, vcc:1, output: 3});
+```
+
+groveを持つデバイスでは、パラメータに{grove: obniz.grove0}を指定することで接続できます。
 ```javascript
 // Javascript Example
 let sensor = obniz.wired("Grove_PressureSensor", {grove: obniz.grove0});

--- a/src/parts/Grove/Grove_PressureSensor/README.md
+++ b/src/parts/Grove/Grove_PressureSensor/README.md
@@ -15,6 +15,12 @@ gnd | `number(obniz Board io)` | no |  &nbsp; | Power Supply
 output | `number(obniz Board io)` | no |  &nbsp; | output pin
 grove | `object` | no | &nbsp;  | grove interface object if a device has
 
+```Javascript
+// Javascript Example
+let sensor = obniz.wired("Grove_PressureSensor", {gnd:0, vcc:1, output: 3});
+```
+
+If the device has a grove interface, it can be connected with just the parameter {grove: obniz.grove0}.
 ```javascript
 // Javascript Example
 let sensor = obniz.wired("Grove_PressureSensor", {grove: obniz.grove0});

--- a/src/parts/Grove/Grove_RotaryAngleSensor/README-ja.md
+++ b/src/parts/Grove/Grove_RotaryAngleSensor/README-ja.md
@@ -5,9 +5,9 @@ Groveコネクタで利用できる可変抵抗です。ボリュームのよう
 回されることで間の１本の電圧が２つの電圧の間を移動します。
 
 ![](image.jpg)
-
-
 このパーツで扱えるポテンションメーターの抵抗値は10Ω〜10kΩの間です。
+
+## wired(obniz, {[signal, vcc, gnd, grove]});
 
 name | type | required | default | description
 --- | --- | --- | --- | ---
@@ -16,6 +16,12 @@ vcc | `number(obniz Board io)` | no |  &nbsp; | VCC端子(2 pin of Grove)
 gnd | `number(obniz Board io)` | no |  &nbsp; | GND端子(0 pin of Grove)
 grove | `object` | no | &nbsp;  | 接続するデバイスにgroveがある場合に利用できます
 
+```Javascript
+// Javascript Example
+const meter = obniz.wired("Grove_RotaryAngleSensor", {gnd:0, vcc:1, signal: 3});
+```
+
+groveを持つデバイスでは、パラメータに{grove: obniz.grove0}を指定することで接続できます。
 ```Javascript
 // Javascript Example
 const meter = obniz.wired("Grove_RotaryAngleSensor", {grove: obniz.grove0});

--- a/src/parts/Grove/Grove_RotaryAngleSensor/README.md
+++ b/src/parts/Grove/Grove_RotaryAngleSensor/README.md
@@ -19,8 +19,12 @@ vcc | `number(obniz Board io)` | no |  &nbsp; | VCC(2 pin of Grove)
 gnd | `number(obniz Board io)` | no |  &nbsp; | GND(0 pin of Grove)
 grove | `object` | no | &nbsp;  | grove interface object if a device has
 
-![](wired.png)
-
+```Javascript
+// Javascript Example
+const meter = obniz.wired("Grove_RotaryAngleSensor", {gnd:0, vcc:1, signal: 3});
+```
+  
+If the device has a grove interface, it can be connected with just the parameter {grove: obniz.grove0}.
 ```Javascript
 // Javascript Example
 const meter = obniz.wired("Grove_RotaryAngleSensor", {grove: obniz.grove0});

--- a/src/parts/Grove/Grove_SoilMoistureSensor/README-ja.md
+++ b/src/parts/Grove/Grove_SoilMoistureSensor/README-ja.md
@@ -17,8 +17,12 @@ gnd | `number(obniz Board io)` | no |  &nbsp; | モジュールの場合はgnd, 
 signal | `number(obniz Board io)` | no |  &nbsp; | signal 出力端子
 grove | `object` | no | &nbsp;  | 接続するデバイスにgroveがある場合に利用できます
 
-![](wired.png)
+```Javascript
+// Javascript Example
+let sensor = obniz.wired("Grove_SoilMoistureSensor", {gnd:0, vcc:1, signal: 3});
+```
 
+groveを持つデバイスでは、パラメータに{grove: obniz.grove0}を指定することで接続できます。
 ```javascript
 // Javascript Example
 let sensor = obniz.wired("Grove_SoilMoistureSensor", {grove: obniz.grove0});

--- a/src/parts/Grove/Grove_SoilMoistureSensor/README.md
+++ b/src/parts/Grove/Grove_SoilMoistureSensor/README.md
@@ -17,6 +17,12 @@ gnd | `number(obniz Board io)` | no |  &nbsp; | Power Supply
 signal | `number(obniz Board iov)` | no |  &nbsp; | signal output pin
 grove | `object` | no | &nbsp;  | grove interface object if a device has
 
+```Javascript
+// Javascript Example
+let sensor = obniz.wired("Grove_SoilMoistureSensor", {gnd:0, vcc:1, signal: 3});
+```
+
+If the device has a grove interface, it can be connected with just the parameter {grove: obniz.grove0}.
 ```javascript
 // Javascript Example
 let sensor = obniz.wired("Grove_SoilMoistureSensor", {grove: obniz.grove0});

--- a/src/parts/Grove/Grove_Speaker/README-ja.md
+++ b/src/parts/Grove/Grove_Speaker/README-ja.md
@@ -17,7 +17,12 @@ gnd | `number(obniz Board io)` | no |  &nbsp; | モジュールの場合はgnd, 
 signal | `number(obniz Board io)` | no |  &nbsp; | signal 出力端子
 grove | `object` | no | &nbsp;  | 接続するデバイスにgroveがある場合に利用できます
 
+```Javascript
+// Javascript Example
+const speaker = obniz.wired("Grove_Speaker", {gnd:0, vcc:1, signal: 3});
+```
 
+groveを持つデバイスでは、パラメータに{grove: obniz.grove0}を指定することで接続できます。
 ```Javascript
 // Javascript Example
 const speaker = obniz.wired("Grove_Speaker", {grove: obniz.grove0})

--- a/src/parts/Grove/Grove_Speaker/README.md
+++ b/src/parts/Grove/Grove_Speaker/README.md
@@ -19,6 +19,12 @@ grove | `object` | no | &nbsp;  | grove interface object if a device has
 
 ```Javascript
 // Javascript Example
+const speaker = obniz.wired("Grove_Speaker", {gnd:0, vcc:1, signal: 3});
+```
+
+If the device has a grove interface, it can be connected with just the parameter {grove: obniz.grove0}.
+```Javascript
+// Javascript Example
 const speaker = obniz.wired("Grove_Speaker", {grove: obniz.grove0})
 ```
 


### PR DESCRIPTION
GroveパーツのBuzzer, GPS, MP3, EarHeartRateをobniz.groveに対応しました。(実機でテストしていない)
ドキュメントにboardとgrove両方での接続方法とobniz.groveについての説明を加えました。
grove_MP3の必要電圧が5vだったので、M5で動くか不明である旨を記載しました。
