### PR TITLE
fix undefined error at obniz.display.font()

### DIFF
--- a/dist/src/obniz/libs/embeds/display.d.ts
+++ b/dist/src/obniz/libs/embeds/display.d.ts
@@ -33,10 +33,9 @@ export default class Display extends ComponentAbstract {
     private _raw_alternate;
     constructor(obniz: any, info: any);
     /**
-     * (It does not work with node.js. Please use display.draw())
-     *
      * This changes the font.
      * The options for fontFamily and fontSize depend on your browser.
+     * If you are using node.js, node-canvas is required.
      *
      * The default font is Arial 16px.
      * If you set the parameter to null, you will be using the default font.
@@ -59,6 +58,7 @@ export default class Display extends ComponentAbstract {
     font(font: string | null, size?: number): void;
     /**
      * Setting color for fill/stroke style for further rendering.
+     * If you are using node.js, node-canvas is required.
      *
      * ```javascript
      * obniz.display.color('#FF0000');
@@ -81,6 +81,7 @@ export default class Display extends ComponentAbstract {
     getColor(): string;
     /**
      * Clear the display.
+     *
      * ```javascript
      * // Javascript Example
      * obniz.display.clear();
@@ -88,8 +89,9 @@ export default class Display extends ComponentAbstract {
      */
     clear(): void;
     /**
-     * (This does not work with node.js. Please use display.draw())
      * It changes the display position of a text. If you are using print() to display a text, position it to top left.
+     *
+     * If you are using node.js, node-canvas is required.
      *
      * ```javascript
      * // Javascript Example
@@ -107,6 +109,7 @@ export default class Display extends ComponentAbstract {
     };
     /**
      * Print text on display.
+     * If you are using node.js and text is included characters out of ASCII code range, node-canvas is required.
      *
      * ```javascript
      * // Javascript Example
@@ -120,14 +123,13 @@ export default class Display extends ComponentAbstract {
      * ```
      * ![](media://obniz_display_print.jpg)
      *
-     * @param text Text to display. With browser, UTF8 string is available. (It does not work with node.js. Please use display.draw())
+     * @param text Text to display. With browser, UTF8 string is available.
+     * @param useCanvas Sets whether or not to force the use of canvas when text is only characters included in ASCII code range. This will be ignored if canvas is not available.
      */
-    print(text: string): void;
+    print(text: string, useCanvas?: boolean): void;
     /**
-     * (It does not work with node.js. Please use display.draw())
-     *
-     *
-     * Now we draw a line between two points.
+     * Draw a line between two points.
+     * If you are using node.js, node-canvas is required.
      *
      * ```javascript
      * // Javascript Example
@@ -150,10 +152,8 @@ export default class Display extends ComponentAbstract {
      */
     line(x_0: number, y_0: number, x_1: number, y_1: number): void;
     /**
-     * (It does not work with node.js. Please use display.draw())
-     *
-     *
-     * This draws a rectangle.
+     * Draw a rectangle.
+     * If you are using node.js, node-canvas is required.
      *
      * ```javascript
      * // Javascript Example
@@ -169,9 +169,8 @@ export default class Display extends ComponentAbstract {
      */
     rect(x: number, y: number, width: number, height: number, mustFill?: boolean): void;
     /**
-     * (It does not work with node.js. Please use display.draw())
-     *
-     * This draws a circle.
+     * Draw a circle.
+     * If you are using node.js, node-canvas is required.
      *
      * ```javascript
      * // Javascript Example
@@ -308,6 +307,7 @@ export default class Display extends ComponentAbstract {
     /**
      * You can specify to transfer the displayed data or not.
      * This affects only the functions that use canvas like clear/print/line/rect/circle/draw.
+     * If you are using node.js, node-canvas is required.
      *
      * Use false to stop updating display and true to restart updating.
      *

--- a/dist/src/obniz/libs/embeds/display.d.ts
+++ b/dist/src/obniz/libs/embeds/display.d.ts
@@ -109,6 +109,7 @@ export default class Display extends ComponentAbstract {
     };
     /**
      * Print text on display.
+     *
      * If you are using node.js and text is included characters out of ASCII code range, node-canvas is required.
      *
      * ```javascript
@@ -124,9 +125,8 @@ export default class Display extends ComponentAbstract {
      * ![](media://obniz_display_print.jpg)
      *
      * @param text Text to display. With browser, UTF8 string is available.
-     * @param useCanvas Sets whether or not to force the use of canvas when text is only characters included in ASCII code range. This will be ignored if canvas is not available.
      */
-    print(text: string, useCanvas?: boolean): void;
+    print(text: string): void;
     /**
      * Draw a line between two points.
      * If you are using node.js, node-canvas is required.

--- a/dist/src/obniz/libs/embeds/display.js
+++ b/dist/src/obniz/libs/embeds/display.js
@@ -154,6 +154,7 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
     // eslint-disable-next-line rulesdir/non-ascii
     /**
      * Print text on display.
+     *
      * If you are using node.js and text is included characters out of ASCII code range, node-canvas is required.
      *
      * ```javascript
@@ -169,28 +170,24 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
      * ![](media://obniz_display_print.jpg)
      *
      * @param text Text to display. With browser, UTF8 string is available.
-     * @param useCanvas Sets whether or not to force the use of canvas when text is only characters included in ASCII code range. This will be ignored if canvas is not available.
      */
-    print(text, useCanvas = false) {
+    print(text) {
         const ctx = this._ctx(false);
-        // eslint-disable-next-line no-control-regex
-        if (text.match(/^[\x00-\x7F]*$/)) {
-            if (!useCanvas || (useCanvas && !ctx)) {
-                const obj = {};
-                obj.display = {
-                    text: '' + text,
-                };
-                this.Obniz.send(obj);
-                return;
-            }
-        }
         if (ctx) {
             ctx.fillText(text, this._pos.x, this._pos.y + this.fontSize);
             this.draw(ctx);
             this._pos.y += this.fontSize;
         }
         else {
-            this.warnCanvasAvailability();
+            // eslint-disable-next-line no-control-regex
+            if (!text.match(/^[\x00-\x7F]*$/)) {
+                this.warnCanvasAvailability();
+            }
+            const obj = {};
+            obj.display = {
+                text: '' + text,
+            };
+            this.Obniz.send(obj);
         }
     }
     /**
@@ -505,7 +502,7 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
     }
     warnCanvasAvailability() {
         if (this.Obniz.isNode) {
-            throw new Error('obniz.js require node-canvas to draw rich contents. see more detail on docs');
+            throw new Error('obniz.js require node-canvas to draw rich contents or characters out of ASCII code range. see more detail on docs');
         }
         else {
             throw new Error('obniz.js cant create canvas element to body');

--- a/dist/src/obniz/libs/embeds/display.js
+++ b/dist/src/obniz/libs/embeds/display.js
@@ -180,7 +180,7 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
         }
         else {
             // eslint-disable-next-line no-control-regex
-            if (!text.match(/^[\x00-\x7F]*$/)) {
+            if (!text.toString().match(/^[\x00-\x7F]*$/)) {
                 this.warnCanvasAvailability();
             }
             const obj = {};

--- a/obniz.js
+++ b/obniz.js
@@ -13434,10 +13434,9 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
         this._reset();
     }
     /**
-     * (It does not work with node.js. Please use display.draw())
-     *
      * This changes the font.
      * The options for fontFamily and fontSize depend on your browser.
+     * If you are using node.js, node-canvas is required.
      *
      * The default font is Arial 16px.
      * If you set the parameter to null, you will be using the default font.
@@ -13458,18 +13457,21 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
      * @param size size of font
      */
     font(font, size) {
-        const ctx = this._ctx();
-        if (typeof size !== 'number') {
-            size = 16;
+        const ctx = this._ctx(true);
+        if (ctx) {
+            if (typeof size !== 'number') {
+                size = 16;
+            }
+            if (typeof font !== 'string') {
+                font = 'Arial';
+            }
+            this.fontSize = size;
+            ctx.font = '' + +' ' + size + 'px ' + font;
         }
-        if (typeof font !== 'string') {
-            font = 'Arial';
-        }
-        this.fontSize = size;
-        ctx.font = '' + +' ' + size + 'px ' + font;
     }
     /**
      * Setting color for fill/stroke style for further rendering.
+     * If you are using node.js, node-canvas is required.
      *
      * ```javascript
      * obniz.display.color('#FF0000');
@@ -13481,10 +13483,12 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
      * @param color css acceptable color definition
      */
     setColor(color) {
-        this._color = color;
-        const ctx = this._ctx();
-        ctx.fillStyle = this._color;
-        ctx.strokeStyle = this._color;
+        const ctx = this._ctx(true);
+        if (ctx) {
+            this._color = color;
+            ctx.fillStyle = this._color;
+            ctx.strokeStyle = this._color;
+        }
     }
     /**
      * Getting color for fill/stroke style for further rendering.
@@ -13499,13 +13503,14 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
     }
     /**
      * Clear the display.
+     *
      * ```javascript
      * // Javascript Example
      * obniz.display.clear();
      * ```
      */
     clear() {
-        const ctx = this._ctx();
+        const ctx = this._ctx(false);
         this._pos.x = 0;
         this._pos.y = 0;
         if (ctx) {
@@ -13525,8 +13530,9 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
     }
     // eslint-disable-next-line rulesdir/non-ascii
     /**
-     * (This does not work with node.js. Please use display.draw())
      * It changes the display position of a text. If you are using print() to display a text, position it to top left.
+     *
+     * If you are using node.js, node-canvas is required.
      *
      * ```javascript
      * // Javascript Example
@@ -13539,7 +13545,7 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
      * @param y
      */
     pos(x, y) {
-        this._ctx(); // crete first
+        this._ctx(true); // crete first
         if (typeof x === 'number') {
             this._pos.x = x;
         }
@@ -13551,6 +13557,7 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
     // eslint-disable-next-line rulesdir/non-ascii
     /**
      * Print text on display.
+     * If you are using node.js and text is included characters out of ASCII code range, node-canvas is required.
      *
      * ```javascript
      * // Javascript Example
@@ -13564,28 +13571,34 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
      * ```
      * ![](media://obniz_display_print.jpg)
      *
-     * @param text Text to display. With browser, UTF8 string is available. (It does not work with node.js. Please use display.draw())
+     * @param text Text to display. With browser, UTF8 string is available.
+     * @param useCanvas Sets whether or not to force the use of canvas when text is only characters included in ASCII code range. This will be ignored if canvas is not available.
      */
-    print(text) {
-        const ctx = this._ctx();
+    print(text, useCanvas = false) {
+        const ctx = this._ctx(false);
+        // eslint-disable-next-line no-control-regex
+        if (text.match(/^[\x00-\x7F]*$/)) {
+            if (!useCanvas || (useCanvas && !ctx)) {
+                const obj = {};
+                obj.display = {
+                    text: '' + text,
+                };
+                this.Obniz.send(obj);
+                return;
+            }
+        }
         if (ctx) {
             ctx.fillText(text, this._pos.x, this._pos.y + this.fontSize);
             this.draw(ctx);
             this._pos.y += this.fontSize;
         }
         else {
-            const obj = {};
-            obj.display = {
-                text: '' + text,
-            };
-            this.Obniz.send(obj);
+            this.warnCanvasAvailability();
         }
     }
     /**
-     * (It does not work with node.js. Please use display.draw())
-     *
-     *
-     * Now we draw a line between two points.
+     * Draw a line between two points.
+     * If you are using node.js, node-canvas is required.
      *
      * ```javascript
      * // Javascript Example
@@ -13607,7 +13620,7 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
      * @param y_1
      */
     line(x_0, y_0, x_1, y_1) {
-        const ctx = this._ctx();
+        const ctx = this._ctx(true);
         if (ctx) {
             ctx.beginPath();
             ctx.moveTo(x_0, y_0);
@@ -13615,15 +13628,10 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
             ctx.stroke();
             this.draw(ctx);
         }
-        else {
-            this.warnCanvasAvailability();
-        }
     }
     /**
-     * (It does not work with node.js. Please use display.draw())
-     *
-     *
-     * This draws a rectangle.
+     * Draw a rectangle.
+     * If you are using node.js, node-canvas is required.
      *
      * ```javascript
      * // Javascript Example
@@ -13638,7 +13646,7 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
      * @param mustFill
      */
     rect(x, y, width, height, mustFill) {
-        const ctx = this._ctx();
+        const ctx = this._ctx(true);
         if (ctx) {
             if (mustFill) {
                 ctx.fillRect(x, y, width, height);
@@ -13648,14 +13656,10 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
             }
             this.draw(ctx);
         }
-        else {
-            this.warnCanvasAvailability();
-        }
     }
     /**
-     * (It does not work with node.js. Please use display.draw())
-     *
-     * This draws a circle.
+     * Draw a circle.
+     * If you are using node.js, node-canvas is required.
      *
      * ```javascript
      * // Javascript Example
@@ -13669,7 +13673,7 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
      * @param mustFill
      */
     circle(x, y, r, mustFill) {
-        const ctx = this._ctx();
+        const ctx = this._ctx(true);
         if (ctx) {
             ctx.beginPath();
             ctx.arc(x, y, r, 0, Math.PI * 2);
@@ -13680,9 +13684,6 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
                 ctx.stroke();
             }
             this.draw(ctx);
-        }
-        else {
-            this.warnCanvasAvailability();
         }
     }
     /**
@@ -13866,6 +13867,7 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
     /**
      * You can specify to transfer the displayed data or not.
      * This affects only the functions that use canvas like clear/print/line/rect/circle/draw.
+     * If you are using node.js, node-canvas is required.
      *
      * Use false to stop updating display and true to restart updating.
      *
@@ -13887,7 +13889,7 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
      */
     drawing(autoFlush) {
         this.autoFlush = !!autoFlush;
-        const ctx = this._ctx();
+        const ctx = this._ctx(true);
         if (ctx) {
             this.draw(ctx);
         }
@@ -13934,8 +13936,7 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
                 this._canvas = createCanvas(this.width, this.height);
             }
             catch (e) {
-                // this.warnCanvasAvailability();
-                return null;
+                return undefined;
             }
         }
         else {
@@ -13963,11 +13964,15 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
         }
         return this._canvas;
     }
-    _ctx() {
+    _ctx(required = false) {
         const canvas = this._preparedCanvas();
         if (canvas) {
             return canvas.getContext('2d');
         }
+        if (required) {
+            this.warnCanvasAvailability();
+        }
+        return undefined;
     }
     _draw(ctx) {
         const raw = new Array((this.width * this.height * this._colorDepth) / 8);
@@ -72393,7 +72398,7 @@ utils.intFromLE = intFromLE;
 /***/ "./node_modules/elliptic/package.json":
 /***/ (function(module) {
 
-module.exports = JSON.parse("{\"author\":{\"name\":\"Fedor Indutny\",\"email\":\"fedor@indutny.com\"},\"bugs\":{\"url\":\"https://github.com/indutny/elliptic/issues\"},\"dependencies\":{\"bn.js\":\"^4.11.9\",\"brorand\":\"^1.1.0\",\"hash.js\":\"^1.0.0\",\"hmac-drbg\":\"^1.0.1\",\"inherits\":\"^2.0.4\",\"minimalistic-assert\":\"^1.0.1\",\"minimalistic-crypto-utils\":\"^1.0.1\"},\"description\":\"EC cryptography\",\"devDependencies\":{\"brfs\":\"^2.0.2\",\"coveralls\":\"^3.1.0\",\"eslint\":\"^7.6.0\",\"grunt\":\"^1.2.1\",\"grunt-browserify\":\"^5.3.0\",\"grunt-cli\":\"^1.3.2\",\"grunt-contrib-connect\":\"^3.0.0\",\"grunt-contrib-copy\":\"^1.0.0\",\"grunt-contrib-uglify\":\"^5.0.0\",\"grunt-mocha-istanbul\":\"^5.0.2\",\"grunt-saucelabs\":\"^9.0.1\",\"istanbul\":\"^0.4.5\",\"mocha\":\"^8.0.1\"},\"files\":[\"lib\"],\"homepage\":\"https://github.com/indutny/elliptic\",\"keywords\":[\"EC\",\"Elliptic\",\"curve\",\"Cryptography\"],\"license\":\"MIT\",\"main\":\"lib/elliptic.js\",\"name\":\"elliptic\",\"repository\":{\"type\":\"git\",\"url\":\"git+ssh://git@github.com/indutny/elliptic.git\"},\"scripts\":{\"lint\":\"eslint lib test\",\"lint:fix\":\"npm run lint -- --fix\",\"test\":\"npm run lint && npm run unit\",\"unit\":\"istanbul test _mocha --reporter=spec test/index.js\",\"version\":\"grunt dist && git add dist/\"},\"version\":\"6.5.4\"}");
+module.exports = JSON.parse("{\"name\":\"elliptic\",\"version\":\"6.5.4\",\"description\":\"EC cryptography\",\"main\":\"lib/elliptic.js\",\"files\":[\"lib\"],\"scripts\":{\"lint\":\"eslint lib test\",\"lint:fix\":\"npm run lint -- --fix\",\"unit\":\"istanbul test _mocha --reporter=spec test/index.js\",\"test\":\"npm run lint && npm run unit\",\"version\":\"grunt dist && git add dist/\"},\"repository\":{\"type\":\"git\",\"url\":\"git@github.com:indutny/elliptic\"},\"keywords\":[\"EC\",\"Elliptic\",\"curve\",\"Cryptography\"],\"author\":\"Fedor Indutny <fedor@indutny.com>\",\"license\":\"MIT\",\"bugs\":{\"url\":\"https://github.com/indutny/elliptic/issues\"},\"homepage\":\"https://github.com/indutny/elliptic\",\"devDependencies\":{\"brfs\":\"^2.0.2\",\"coveralls\":\"^3.1.0\",\"eslint\":\"^7.6.0\",\"grunt\":\"^1.2.1\",\"grunt-browserify\":\"^5.3.0\",\"grunt-cli\":\"^1.3.2\",\"grunt-contrib-connect\":\"^3.0.0\",\"grunt-contrib-copy\":\"^1.0.0\",\"grunt-contrib-uglify\":\"^5.0.0\",\"grunt-mocha-istanbul\":\"^5.0.2\",\"grunt-saucelabs\":\"^9.0.1\",\"istanbul\":\"^0.4.5\",\"mocha\":\"^8.0.1\"},\"dependencies\":{\"bn.js\":\"^4.11.9\",\"brorand\":\"^1.1.0\",\"hash.js\":\"^1.0.0\",\"hmac-drbg\":\"^1.0.1\",\"inherits\":\"^2.0.4\",\"minimalistic-assert\":\"^1.0.1\",\"minimalistic-crypto-utils\":\"^1.0.1\"}}");
 
 /***/ }),
 

--- a/obniz.js
+++ b/obniz.js
@@ -13583,7 +13583,7 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
         }
         else {
             // eslint-disable-next-line no-control-regex
-            if (!text.match(/^[\x00-\x7F]*$/)) {
+            if (!text.toString().match(/^[\x00-\x7F]*$/)) {
                 this.warnCanvasAvailability();
             }
             const obj = {};

--- a/obniz.js
+++ b/obniz.js
@@ -13557,6 +13557,7 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
     // eslint-disable-next-line rulesdir/non-ascii
     /**
      * Print text on display.
+     *
      * If you are using node.js and text is included characters out of ASCII code range, node-canvas is required.
      *
      * ```javascript
@@ -13572,28 +13573,24 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
      * ![](media://obniz_display_print.jpg)
      *
      * @param text Text to display. With browser, UTF8 string is available.
-     * @param useCanvas Sets whether or not to force the use of canvas when text is only characters included in ASCII code range. This will be ignored if canvas is not available.
      */
-    print(text, useCanvas = false) {
+    print(text) {
         const ctx = this._ctx(false);
-        // eslint-disable-next-line no-control-regex
-        if (text.match(/^[\x00-\x7F]*$/)) {
-            if (!useCanvas || (useCanvas && !ctx)) {
-                const obj = {};
-                obj.display = {
-                    text: '' + text,
-                };
-                this.Obniz.send(obj);
-                return;
-            }
-        }
         if (ctx) {
             ctx.fillText(text, this._pos.x, this._pos.y + this.fontSize);
             this.draw(ctx);
             this._pos.y += this.fontSize;
         }
         else {
-            this.warnCanvasAvailability();
+            // eslint-disable-next-line no-control-regex
+            if (!text.match(/^[\x00-\x7F]*$/)) {
+                this.warnCanvasAvailability();
+            }
+            const obj = {};
+            obj.display = {
+                text: '' + text,
+            };
+            this.Obniz.send(obj);
         }
     }
     /**
@@ -13908,7 +13905,7 @@ class Display extends ComponentAbstact_1.ComponentAbstract {
     }
     warnCanvasAvailability() {
         if (this.Obniz.isNode) {
-            throw new Error('obniz.js require node-canvas to draw rich contents. see more detail on docs');
+            throw new Error('obniz.js require node-canvas to draw rich contents or characters out of ASCII code range. see more detail on docs');
         }
         else {
             throw new Error('obniz.js cant create canvas element to body');

--- a/src/obniz/libs/embeds/display.ts
+++ b/src/obniz/libs/embeds/display.ts
@@ -175,6 +175,7 @@ export default class Display extends ComponentAbstract {
   // eslint-disable-next-line rulesdir/non-ascii
   /**
    * Print text on display.
+   *
    * If you are using node.js and text is included characters out of ASCII code range, node-canvas is required.
    *
    * ```javascript
@@ -190,27 +191,23 @@ export default class Display extends ComponentAbstract {
    * ![](media://obniz_display_print.jpg)
    *
    * @param text Text to display. With browser, UTF8 string is available.
-   * @param useCanvas Sets whether or not to force the use of canvas when text is only characters included in ASCII code range. This will be ignored if canvas is not available.
    */
-  public print(text: string, useCanvas = false) {
+  public print(text: string) {
     const ctx = this._ctx(false);
-    // eslint-disable-next-line no-control-regex
-    if (text.match(/^[\x00-\x7F]*$/)) {
-      if (!useCanvas || (useCanvas && !ctx)) {
-        const obj: any = {};
-        obj.display = {
-          text: '' + text,
-        };
-        this.Obniz.send(obj);
-        return;
-      }
-    }
     if (ctx) {
       ctx.fillText(text, this._pos.x, this._pos.y + this.fontSize);
       this.draw(ctx);
       this._pos.y += this.fontSize;
     } else {
-      this.warnCanvasAvailability();
+      // eslint-disable-next-line no-control-regex
+      if (!text.match(/^[\x00-\x7F]*$/)) {
+        this.warnCanvasAvailability();
+      }
+      const obj: any = {};
+      obj.display = {
+        text: '' + text,
+      };
+      this.Obniz.send(obj);
     }
   }
 
@@ -552,7 +549,7 @@ export default class Display extends ComponentAbstract {
   private warnCanvasAvailability() {
     if (this.Obniz.isNode) {
       throw new Error(
-        'obniz.js require node-canvas to draw rich contents. see more detail on docs'
+        'obniz.js require node-canvas to draw rich contents or characters out of ASCII code range. see more detail on docs'
       );
     } else {
       throw new Error('obniz.js cant create canvas element to body');

--- a/src/obniz/libs/embeds/display.ts
+++ b/src/obniz/libs/embeds/display.ts
@@ -200,7 +200,7 @@ export default class Display extends ComponentAbstract {
       this._pos.y += this.fontSize;
     } else {
       // eslint-disable-next-line no-control-regex
-      if (!text.match(/^[\x00-\x7F]*$/)) {
+      if (!text.toString().match(/^[\x00-\x7F]*$/)) {
         this.warnCanvasAvailability();
       }
       const obj: any = {};


### PR DESCRIPTION
- obniz.display 内の canvas 初期化処理失敗時の例外処理を各描画関数ではなく、初期化関数内で行うように変更
- obniz.display.print() で ASCII コード範囲外の文字列が含まれる場合に canvas の利用を必須とするように変更
- canvas 初期化失敗時のメッセージを変更