### PR TITLE
BleScanのstartWait()の引数warning追加

### DIFF
--- a/dist/src/obniz/libs/embeds/bleHci/bleScan.d.ts
+++ b/dist/src/obniz/libs/embeds/bleHci/bleScan.d.ts
@@ -288,6 +288,7 @@ export default class BleScan {
     private isBinaryTarget;
     private isUuidTarget;
     private isDeviceAddressTarget;
+    private isContainingBleScanSettingProperty;
     private _clearDelayNotifyTimer;
     private _removeDelayNotifyTimer;
 }

--- a/dist/src/obniz/libs/embeds/bleHci/bleScan.js
+++ b/dist/src/obniz/libs/embeds/bleHci/bleScan.js
@@ -94,7 +94,7 @@ class BleScan {
         if (this.isContainingBleScanSettingProperty(target)) {
             this.obnizBle.Obniz.warning({
                 alert: 'warning',
-                message: `Unexpected arguments. It might be contained the second argument keys. Please check object keys and order of 'obniz.ble.getWait()' arguments. `,
+                message: `Unexpected arguments. It might be contained the second argument keys. Please check object keys and order of 'startWait()' / 'startOneWait()' / 'startAllWait()' arguments. `,
             });
         }
         this.state = 'starting';

--- a/dist/src/obniz/libs/embeds/bleHci/bleScan.js
+++ b/dist/src/obniz/libs/embeds/bleHci/bleScan.js
@@ -91,6 +91,12 @@ class BleScan {
      */
     async startWait(target = {}, settings = {}) {
         this.obnizBle.warningIfNotInitialize();
+        if (this.isContainingBleScanSettingProperty(target)) {
+            this.obnizBle.Obniz.warning({
+                alert: 'warning',
+                message: `Unexpected arguments. It might be contained the second argument keys. Please check object keys and order of 'obniz.ble.getWait()' arguments. `,
+            });
+        }
         this.state = 'starting';
         const timeout = settings.duration === undefined ? 30 : settings.duration;
         settings.duplicate = !!settings.duplicate;
@@ -518,6 +524,19 @@ class BleScan {
             if (deviceAddress === peripheral.address) {
                 return true;
             }
+        }
+        return false;
+    }
+    isContainingBleScanSettingProperty(arg) {
+        if (arg === null) {
+            return false;
+        }
+        else if ('duration' in arg ||
+            'duplicate' in arg ||
+            'activeScan' in arg ||
+            'filterOnDevice' in arg ||
+            'waitBothAdvertisementAndScanResponse' in arg) {
+            return true;
         }
         return false;
     }

--- a/docs/obnizjs/classes/obnizcore.components.ble.hci.blescan.html
+++ b/docs/obnizjs/classes/obnizcore.components.ble.hci.blescan.html
@@ -224,7 +224,7 @@ obniz.ble.scan.onfinish = <span class="hljs-function"><span class="hljs-keyword"
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/obniz/libs/embeds/bleHci/bleScan.ts:503</li>
+									<li>Defined in src/obniz/libs/embeds/bleHci/bleScan.ts:509</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -246,7 +246,7 @@ obniz.ble.scan.onfinish = <span class="hljs-function"><span class="hljs-keyword"
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/obniz/libs/embeds/bleHci/bleScan.ts:420</li>
+									<li>Defined in src/obniz/libs/embeds/bleHci/bleScan.ts:426</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -272,7 +272,7 @@ obniz.ble.scan.onfinish = <span class="hljs-function"><span class="hljs-keyword"
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/obniz/libs/embeds/bleHci/bleScan.ts:442</li>
+									<li>Defined in src/obniz/libs/embeds/bleHci/bleScan.ts:448</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -334,7 +334,7 @@ obniz.ble.scan.onfinish = <span class="hljs-function"><span class="hljs-keyword"
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/obniz/libs/embeds/bleHci/bleScan.ts:396</li>
+									<li>Defined in src/obniz/libs/embeds/bleHci/bleScan.ts:402</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -384,7 +384,7 @@ obniz.ble.scan.onfinish = <span class="hljs-function"><span class="hljs-keyword"
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/obniz/libs/embeds/bleHci/bleScan.ts:337</li>
+									<li>Defined in src/obniz/libs/embeds/bleHci/bleScan.ts:343</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/obniz.js
+++ b/obniz.js
@@ -8685,7 +8685,7 @@ class BleScan {
         if (this.isContainingBleScanSettingProperty(target)) {
             this.obnizBle.Obniz.warning({
                 alert: 'warning',
-                message: `Unexpected arguments. It might be contained the second argument keys. Please check object keys and order of 'obniz.ble.getWait()' arguments. `,
+                message: `Unexpected arguments. It might be contained the second argument keys. Please check object keys and order of 'startWait()' / 'startOneWait()' / 'startAllWait()' arguments. `,
             });
         }
         this.state = 'starting';

--- a/obniz.js
+++ b/obniz.js
@@ -8682,6 +8682,12 @@ class BleScan {
      */
     async startWait(target = {}, settings = {}) {
         this.obnizBle.warningIfNotInitialize();
+        if (this.isContainingBleScanSettingProperty(target)) {
+            this.obnizBle.Obniz.warning({
+                alert: 'warning',
+                message: `Unexpected arguments. It might be contained the second argument keys. Please check object keys and order of 'obniz.ble.getWait()' arguments. `,
+            });
+        }
         this.state = 'starting';
         const timeout = settings.duration === undefined ? 30 : settings.duration;
         settings.duplicate = !!settings.duplicate;
@@ -9109,6 +9115,19 @@ class BleScan {
             if (deviceAddress === peripheral.address) {
                 return true;
             }
+        }
+        return false;
+    }
+    isContainingBleScanSettingProperty(arg) {
+        if (arg === null) {
+            return false;
+        }
+        else if ('duration' in arg ||
+            'duplicate' in arg ||
+            'activeScan' in arg ||
+            'filterOnDevice' in arg ||
+            'waitBothAdvertisementAndScanResponse' in arg) {
+            return true;
         }
         return false;
     }

--- a/src/obniz/libs/embeds/bleHci/bleScan.ts
+++ b/src/obniz/libs/embeds/bleHci/bleScan.ts
@@ -269,7 +269,7 @@ export default class BleScan {
     if (this.isContainingBleScanSettingProperty(target)) {
       this.obnizBle.Obniz.warning({
         alert: 'warning',
-        message: `Unexpected arguments. It might be contained the second argument keys. Please check object keys and order of 'obniz.ble.getWait()' arguments. `,
+        message: `Unexpected arguments. It might be contained the second argument keys. Please check object keys and order of 'startWait()' / 'startOneWait()' / 'startAllWait()' arguments. `,
       });
     }
     this.state = 'starting';

--- a/src/obniz/libs/embeds/bleHci/bleScan.ts
+++ b/src/obniz/libs/embeds/bleHci/bleScan.ts
@@ -266,6 +266,12 @@ export default class BleScan {
     settings: BleScanSetting = {}
   ) {
     this.obnizBle.warningIfNotInitialize();
+    if (this.isContainingBleScanSettingProperty(target)) {
+      this.obnizBle.Obniz.warning({
+        alert: 'warning',
+        message: `Unexpected arguments. It might be contained the second argument keys. Please check object keys and order of 'obniz.ble.getWait()' arguments. `,
+      });
+    }
     this.state = 'starting';
 
     const timeout: number | null =
@@ -768,6 +774,21 @@ export default class BleScan {
       if (deviceAddress === peripheral.address) {
         return true;
       }
+    }
+    return false;
+  }
+
+  private isContainingBleScanSettingProperty(arg: any): arg is BleScanSetting {
+    if (arg === null) {
+      return false;
+    } else if (
+      'duration' in arg ||
+      'duplicate' in arg ||
+      'activeScan' in arg ||
+      'filterOnDevice' in arg ||
+      'waitBothAdvertisementAndScanResponse' in arg
+    ) {
+      return true;
     }
     return false;
   }


### PR DESCRIPTION
obniz.ble.scan.startWait()の第一引数のtargetがnullでなかった場合、
本来第二引数のsettingsのキーが含まれていないかを判定して、
含まれていたらwarningを出すようにしました。