### PR TITLE
fix/local name regex

### DIFF
--- a/dist/src/parts/Ble/RS_BTEVS1/index.js
+++ b/dist/src/parts/Ble/RS_BTEVS1/index.js
@@ -201,7 +201,7 @@ RS_BTEVS1.PartsName = 'RS_BTEVS1';
  * BTEVS-1234: ~1.0.2
  * EVS-1234: 1.1.2~
  */
-RS_BTEVS1.LocalName = /(BT|)EVS-[0-9A-F]{4}/;
+RS_BTEVS1.LocalName = /^(BT)?EVS-[0-9A-F]{4}$/;
 // public static readonly BeaconDataLength: ObnizPartsBleCompare<
 //   number | null
 // > = 0x0c;

--- a/dist/src/parts/Ble/RS_BTEVS1/index.js
+++ b/dist/src/parts/Ble/RS_BTEVS1/index.js
@@ -201,7 +201,7 @@ RS_BTEVS1.PartsName = 'RS_BTEVS1';
  * BTEVS-1234: ~1.0.2
  * EVS-1234: 1.1.2~
  */
-RS_BTEVS1.LocalName = /^(BT)?EVS-[0-9A-F]{4}$/;
+RS_BTEVS1.LocalName = /^(BT)?EVS-[0-9A-F]{4}/;
 // public static readonly BeaconDataLength: ObnizPartsBleCompare<
 //   number | null
 // > = 0x0c;

--- a/dist/src/parts/Ble/RS_BTEVS1/index.js
+++ b/dist/src/parts/Ble/RS_BTEVS1/index.js
@@ -201,7 +201,7 @@ RS_BTEVS1.PartsName = 'RS_BTEVS1';
  * BTEVS-1234: ~1.0.2
  * EVS-1234: 1.1.2~
  */
-RS_BTEVS1.LocalName = /(BT|)EVS-[0-9A-E]{4}/;
+RS_BTEVS1.LocalName = /(BT|)EVS-[0-9A-F]{4}/;
 // public static readonly BeaconDataLength: ObnizPartsBleCompare<
 //   number | null
 // > = 0x0c;

--- a/obniz.js
+++ b/obniz.js
@@ -28131,7 +28131,7 @@ RS_BTEVS1.PartsName = 'RS_BTEVS1';
  * BTEVS-1234: ~1.0.2
  * EVS-1234: 1.1.2~
  */
-RS_BTEVS1.LocalName = /^(BT)?EVS-[0-9A-F]{4}$/;
+RS_BTEVS1.LocalName = /^(BT)?EVS-[0-9A-F]{4}/;
 // public static readonly BeaconDataLength: ObnizPartsBleCompare<
 //   number | null
 // > = 0x0c;

--- a/obniz.js
+++ b/obniz.js
@@ -28131,7 +28131,7 @@ RS_BTEVS1.PartsName = 'RS_BTEVS1';
  * BTEVS-1234: ~1.0.2
  * EVS-1234: 1.1.2~
  */
-RS_BTEVS1.LocalName = /(BT|)EVS-[0-9A-F]{4}/;
+RS_BTEVS1.LocalName = /^(BT)?EVS-[0-9A-F]{4}$/;
 // public static readonly BeaconDataLength: ObnizPartsBleCompare<
 //   number | null
 // > = 0x0c;

--- a/obniz.js
+++ b/obniz.js
@@ -28131,7 +28131,7 @@ RS_BTEVS1.PartsName = 'RS_BTEVS1';
  * BTEVS-1234: ~1.0.2
  * EVS-1234: 1.1.2~
  */
-RS_BTEVS1.LocalName = /(BT|)EVS-[0-9A-E]{4}/;
+RS_BTEVS1.LocalName = /(BT|)EVS-[0-9A-F]{4}/;
 // public static readonly BeaconDataLength: ObnizPartsBleCompare<
 //   number | null
 // > = 0x0c;
@@ -100768,9 +100768,7 @@ var global = getGlobal();
 module.exports = exports = global.fetch;
 
 // Needed for TypeScript and Webpack.
-if (global.fetch) {
-	exports.default = global.fetch.bind(global);
-}
+exports.default = global.fetch.bind(global);
 
 exports.Headers = global.Headers;
 exports.Request = global.Request;

--- a/src/parts/Ble/RS_BTEVS1/index.ts
+++ b/src/parts/Ble/RS_BTEVS1/index.ts
@@ -141,7 +141,7 @@ export default class RS_BTEVS1 extends ObnizPartsBleConnectable<
    * BTEVS-1234: ~1.0.2
    * EVS-1234: 1.1.2~
    */
-  public static readonly LocalName = /(BT|)EVS-[0-9A-F]{4}/;
+  public static readonly LocalName = /^(BT)?EVS-[0-9A-F]{4}$/;
 
   // public static readonly BeaconDataLength: ObnizPartsBleCompare<
   //   number | null

--- a/src/parts/Ble/RS_BTEVS1/index.ts
+++ b/src/parts/Ble/RS_BTEVS1/index.ts
@@ -141,7 +141,7 @@ export default class RS_BTEVS1 extends ObnizPartsBleConnectable<
    * BTEVS-1234: ~1.0.2
    * EVS-1234: 1.1.2~
    */
-  public static readonly LocalName = /(BT|)EVS-[0-9A-E]{4}/;
+  public static readonly LocalName = /(BT|)EVS-[0-9A-F]{4}/;
 
   // public static readonly BeaconDataLength: ObnizPartsBleCompare<
   //   number | null

--- a/src/parts/Ble/RS_BTEVS1/index.ts
+++ b/src/parts/Ble/RS_BTEVS1/index.ts
@@ -141,7 +141,7 @@ export default class RS_BTEVS1 extends ObnizPartsBleConnectable<
    * BTEVS-1234: ~1.0.2
    * EVS-1234: 1.1.2~
    */
-  public static readonly LocalName = /^(BT)?EVS-[0-9A-F]{4}$/;
+  public static readonly LocalName = /^(BT)?EVS-[0-9A-F]{4}/;
 
   // public static readonly BeaconDataLength: ObnizPartsBleCompare<
   //   number | null


### PR DESCRIPTION
RS_BTEVS1のlocalnameのregex定義の修正
localnameのフォーマットは`(BT)EVS-[macaddressの下４桁]`で、macaddressの下４桁は16進数。