### PR TITLE
fix: MT-500BT cnkey Zero-padded 4-digit

### DIFF
--- a/dist/src/parts/Ble/MT_500BT/index.js
+++ b/dist/src/parts/Ble/MT_500BT/index.js
@@ -135,7 +135,7 @@ class MT_500BT {
      * 通信開始コマンドを送信
      */
     async startCommunicationCommandWait() {
-        const cnkey = '' + MT_500BT.getCNKey(this._peripheral); // to string
+        const cnkey = ('' + MT_500BT.getCNKey(this._peripheral)).padStart(4, '0'); // to string
         const CNKeyBuf = Buffer.from(cnkey, 'utf8');
         const startCommand = this._createCommand(0xfd, Array.from(CNKeyBuf));
         // console.log("sendDataReplyWait");

--- a/obniz.js
+++ b/obniz.js
@@ -29564,7 +29564,7 @@ class MT_500BT {
      * 通信開始コマンドを送信
      */
     async startCommunicationCommandWait() {
-        const cnkey = '' + MT_500BT.getCNKey(this._peripheral); // to string
+        const cnkey = ('' + MT_500BT.getCNKey(this._peripheral)).padStart(4, '0'); // to string
         const CNKeyBuf = Buffer.from(cnkey, 'utf8');
         const startCommand = this._createCommand(0xfd, Array.from(CNKeyBuf));
         // console.log("sendDataReplyWait");

--- a/src/parts/Ble/MT_500BT/index.ts
+++ b/src/parts/Ble/MT_500BT/index.ts
@@ -162,7 +162,7 @@ export default class MT_500BT implements ObnizPartsInterface {
    * 通信開始コマンドを送信
    */
   public async startCommunicationCommandWait() {
-    const cnkey = '' + MT_500BT.getCNKey(this._peripheral); // to string
+    const cnkey = ('' + MT_500BT.getCNKey(this._peripheral)).padStart(4, '0'); // to string
     const CNKeyBuf = Buffer.from(cnkey, 'utf8');
     const startCommand = this._createCommand(0xfd, Array.from(CNKeyBuf));
     // console.log("sendDataReplyWait");


### PR DESCRIPTION
## 発生事象

MT-500BT の機器に登録されているcnkeyが「0618」の機器を利用した場合、
[サンプルコード](https://github.com/obniz/obniz/tree/master/src/parts/Ble/MT_500BT#gettemperaturewait)を実行するとdevice.getTemperatureWait()の処理にて以下のエラーが表示され、Obnizの処理が停止しました。

```
ObnizBleUnknownPeripheralError: unknown peripheral :90b686a06d0a
    at NobleBindings.getGatt (/mydrive/workspaces/myobniz/node_modules/obniz/dist/src/obniz/libs/embeds/bleHci/protocol/central/bindings.js:381:19)
    at NobleBindings.writeWait (/mydrive/workspaces/myobniz/node_modules/obniz/dist/src/obniz/libs/embeds/bleHci/protocol/central/bindings.js:303:27)
    at BleRemoteCharacteristic.writeWait (/mydrive/workspaces/myobniz/node_modules/obniz/dist/src/obniz/libs/embeds/bleHci/bleRemoteCharacteristic.js:314:64)
    at /mydrive/workspaces/myobniz/node_modules/obniz/dist/src/parts/Ble/MT_500BT/index.js:328:29
    at new Promise (<anonymous>)
    at MT_500BT._sendDataReplyWait (/mydrive/workspaces/myobniz/node_modules/obniz/dist/src/parts/Ble/MT_500BT/index.js:317:16)
    at MT_500BT.getTemperatureWait (/mydrive/workspaces/myobniz/node_modules/obniz/dist/src/parts/Ble/MT_500BT/index.js:255:32)
    at obniz.ble.scan.onfind (/mydrive/workspaces/myobniz/app.js:273:35)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  code: 5,
  peripheralUuid: '90b686a06d0a'
}
```

## 原因箇所

直前の device.connectWait(); が呼ばれたときに、以下のエラーが吐かれており、
MT-500BTの通信に必要な処理が失敗していることが分かりました。

```
Error: StartCommunicationError 35
    at MT_500BT.startCommunicationCommandWait (/mydrive/workspaces/myobniz/node_modules/obniz/dist/src/parts/Ble/MT_500BT/index.js:146:19)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async MT_500BT.connectWait (/mydrive/workspaces/myobniz/node_modules/obniz/dist/src/parts/Ble/MT_500BT/index.js:126:13)
    at async obniz.ble.scan.onfind (/mydrive/workspaces/myobniz/app.js:266:26)
```

今回利用していたMT-500BT の機器は「0618」という値のため、
以下の機器との通信で扱うcnkeyは、「618」ではなく「0618」で処理する必要があります。

https://github.com/obniz/obniz/blob/2809d60261a1283ea538d9dff96e153e91dfb585/src/parts/Ble/MT_500BT/index.ts#L164-L173

## 実機確認

以下の2機種で実機確認を行い、データを取得できることを確認しました。

- MT-500BT (cnkey= 0618)
- MT-550BT (cnkey= 6730)