### PR TITLE
fixed a luck of module 'p-limit'

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "moment": "^2.29.3",
     "node-dir": "^0.1.17",
     "node-fetch": "^2.3.0",
+    "p-limit": "^3.1.0",
     "round-to": "^5.0.0",
     "semver": "^5.7.0",
     "strict-event-emitter": "^0.2.6",


### PR DESCRIPTION
Node-RED module node-red-contrib-obniz doesn't work after a release of obniz v3.30.0

Node-RED console logs below
```
[warn] [node-red-contrib-obniz/obniz] Error: Cannot find module 'p-limit'
[warn] [node-red-contrib-obniz/obniz-repeat] Error: Cannot find module 'p-limit'
[warn] [node-red-contrib-obniz/obniz-function] Error: Cannot find module 'p-limit'
```

obniz/dist/src/obniz/libs/embeds/bleHci/bleRemoteCommandSequence.js imports 'p-limit', but doesn't find module.

added 'p-limit' module to package.json in "dependencies" section. the reason of version 3.1.0 is to support CommonJS by using from Node.js.

cf.
https://stackoverflow.com/questions/69956414/how-to-import-node-module-in-typescript-project-err-require-esm

p-limit 4.0.0 and above are now ESM only. You can downgrade p-limit to 3.1.0 which is commonjs and it should work fine.