### PR TITLE
Binary Analyzserの追加

### DIFF
--- a/src/obniz/libs/utils/binaryAnalyzer/binaryAnalyzer.spec.ts
+++ b/src/obniz/libs/utils/binaryAnalyzer/binaryAnalyzer.spec.ts
@@ -1,0 +1,51 @@
+import { BinaryAnalyzer } from './binaryAnalyzer';
+
+const analyzer = new BinaryAnalyzer()
+  .addTarget('a', [0, 1], 'UIntBE') // 固定値
+  .addTarget('a2', [2, 3], 'UIntLE') // 固定値
+  .addTargetByLength('b', 3, 'Ascii') // 3byteの文字列が入る
+  .addTarget('c', [-1, -1], 'RawArray') // -1は何が入るか不明な場合
+  .addGroup(
+    'd',
+    new BinaryAnalyzer()
+      .addTarget('sx', [-1, -1], 'UIntLE', (v) => v / 100)
+      .addTarget('sy', [-1, -1], 'UIntLE', (v) => 'value:' + v)
+      .addTarget('sz', [-1, -1], 'UIntLE', (v) => ({ v }))
+  )
+  .addGroup('e', (
+    a // arrow関数で書くことも可能
+  ) => a.addTarget('sss', [-1, -1, -1, -1], 'RawArray'));
+
+const targetData = [
+  0x00,
+  0x01,
+  0x02,
+  0x03,
+  0x04,
+  0x05,
+  0x06,
+  0x07,
+  0x08,
+  0x09,
+  0x0a,
+  0x0b,
+  0x0c,
+  0x0d,
+  0x0e,
+  0x0f,
+  0x10,
+];
+
+const isValid = analyzer.validate(targetData);
+const data = analyzer.getAllData(targetData); // validじゃない場合はnullが返ってくる
+
+if (data) {
+  console.log(data.a); // number
+  console.log(data.a2); // number
+  console.log(data.b); // string
+  console.log(data.c); // number[]
+  console.log(data.d.sx); // number
+  console.log(data.d.sy); // string
+  console.log(data.d.sz); // object
+  console.log(data.e.sss); // number[]
+}

--- a/src/obniz/libs/utils/binaryAnalyzer/binaryAnalyzer.ts
+++ b/src/obniz/libs/utils/binaryAnalyzer/binaryAnalyzer.ts
@@ -1,0 +1,205 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type BinaryAnalyzerKey = keyof any;
+
+export type BinaryAnalyzerParserResultType = {
+  Ascii: string;
+  UIntBE: number;
+  UIntLE: number;
+  RawArray: number[];
+};
+export type BinaryAnalyzerParserType = keyof BinaryAnalyzerParserResultType;
+
+type BinaryAnalyzerParserPostProcessFunc<
+  Type extends BinaryAnalyzerParserType,
+  Result = any
+> = (data: BinaryAnalyzerParserResultType[Type]) => Result;
+
+export interface BinaryAnalyzerParserRow<
+  Key extends BinaryAnalyzerKey,
+  Type extends BinaryAnalyzerParserType
+> {
+  name: Key;
+  filter: number[];
+  type: Type;
+  postProcess?: BinaryAnalyzerParserPostProcessFunc<Type>;
+}
+
+export interface BinaryAnalyzerNestRow<Key extends BinaryAnalyzerKey> {
+  name: Key;
+  filter: BinaryAnalyzer<any>;
+}
+
+export type BinaryAnalyzerRow<
+  Key extends BinaryAnalyzerKey,
+  Type extends BinaryAnalyzerParserType
+> = BinaryAnalyzerNestRow<Key> | BinaryAnalyzerParserRow<Key, Type>;
+
+export class BinaryAnalyzer<
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  OUTPUT extends Record<BinaryAnalyzerKey, any> = {}
+> {
+  private _target: BinaryAnalyzerRow<keyof OUTPUT, any>[] = [];
+
+  addTarget<N extends BinaryAnalyzerKey, Type extends BinaryAnalyzerParserType>(
+    name: N,
+    filter: number[],
+    type: Type
+  ): BinaryAnalyzer<
+    { [key in N]: BinaryAnalyzerParserResultType[Type] } & OUTPUT
+  >;
+
+  addTarget<
+    N extends BinaryAnalyzerKey,
+    Type extends BinaryAnalyzerParserType,
+    Result
+  >(
+    name: N,
+    filter: number[],
+    type: Type,
+    postProcess?: BinaryAnalyzerParserPostProcessFunc<Type, Result>
+  ): BinaryAnalyzer<{ [key in N]: Result } & OUTPUT>;
+
+  addTarget<
+    N extends BinaryAnalyzerKey,
+    Type extends BinaryAnalyzerParserType,
+    Result
+  >(
+    name: N,
+    filter: number[],
+    type: Type,
+    postProcess?: BinaryAnalyzerParserPostProcessFunc<Type, Result>
+  ): BinaryAnalyzer<{ [key in N]: Result } & OUTPUT> {
+    this._target.push({ name, filter, type, postProcess });
+    return this as BinaryAnalyzer<{ [key in N]: number[] } & OUTPUT>;
+  }
+
+  addTargetByLength<
+    N extends BinaryAnalyzerKey,
+    Type extends BinaryAnalyzerParserType
+  >(
+    name: N,
+    length: number,
+    type: Type
+  ): BinaryAnalyzer<
+    { [key in N]: BinaryAnalyzerParserResultType[Type] } & OUTPUT
+  >;
+
+  addTargetByLength<
+    N extends BinaryAnalyzerKey,
+    Type extends BinaryAnalyzerParserType,
+    Result
+  >(
+    name: N,
+    length: number,
+    type: Type,
+    postProcess?: BinaryAnalyzerParserPostProcessFunc<Type, Result>
+  ): BinaryAnalyzer<{ [key in N]: Result } & OUTPUT>;
+
+  addTargetByLength<
+    N extends BinaryAnalyzerKey,
+    Type extends BinaryAnalyzerParserType,
+    Result
+  >(
+    name: N,
+    length: number,
+    type: Type,
+    postProcess?: BinaryAnalyzerParserPostProcessFunc<Type, Result>
+  ): BinaryAnalyzer<{ [key in N]: Result } & OUTPUT> {
+    return this.addTarget(name, new Array(length).fill(-1), type, postProcess);
+  }
+
+  addGroup<
+    N extends BinaryAnalyzerKey,
+    NEST extends Record<BinaryAnalyzerKey, any>
+  >(
+    name: N,
+    fnOrAnalyzer:
+      | BinaryAnalyzer<NEST>
+      | ((analyzer: BinaryAnalyzer) => BinaryAnalyzer<NEST>)
+  ): BinaryAnalyzer<
+    {
+      [key in N]: NonNullable<ReturnType<BinaryAnalyzer<NEST>['getAllData']>>;
+    } &
+      OUTPUT
+  > {
+    const analyzer =
+      fnOrAnalyzer instanceof BinaryAnalyzer
+        ? fnOrAnalyzer
+        : fnOrAnalyzer(new BinaryAnalyzer());
+    this._target.push({ name, filter: analyzer });
+    return this as BinaryAnalyzer<
+      { [key in N]: ReturnType<BinaryAnalyzer<NEST>['getAllData']> } & OUTPUT
+    >;
+  }
+
+  /**
+   * 登録済みbinaryAnarlyzerのGroupを解除して、Flatな条件Arrayを作る
+   */
+  flat(): number[] {
+    return this._target.reduce(
+      (acc: number[], val: BinaryAnalyzerRow<any, any>) => {
+        if (val.filter instanceof BinaryAnalyzer) {
+          return [...acc, ...val.filter.flat()];
+        }
+        return [...acc, ...val.filter];
+      },
+      []
+    );
+  }
+
+  length(): number {
+    return this.flat().length;
+  }
+
+  validate(target: number[] | string | Buffer): boolean {
+    const targetArray = this._convertToNumberArray(target);
+    const flat = this.flat();
+    if (flat.length > targetArray.length) {
+      return false;
+    }
+    for (let index = 0; index < flat.length; index++) {
+      if (flat[index] === -1) {
+        continue;
+      }
+      if (targetArray[index] === flat[index]) {
+        continue;
+      }
+      return false;
+    }
+    return true;
+  }
+
+  getAllData(target: number[] | string | Buffer): OUTPUT | null {
+    const targetArray = this._convertToNumberArray(target);
+    if (!this.validate(targetArray)) {
+      return null;
+    }
+    const result: any = {};
+
+    let index = 0;
+    for (const one of this._target) {
+      if (one.filter instanceof BinaryAnalyzer) {
+        const newTarget = targetArray.slice(index, index + one.filter.length());
+        result[one.name] = one.filter.getAllData(newTarget);
+      } else {
+        result[one.name] = targetArray.slice(index, index + one.filter.length);
+      }
+      if (one.filter instanceof BinaryAnalyzer) {
+        index += one.filter.length();
+      } else {
+        index += one.filter.length;
+      }
+    }
+
+    return result;
+  }
+
+  private _convertToNumberArray(target: number[] | string | Buffer) {
+    if (Array.isArray(target)) {
+      return target;
+    }
+    const buf =
+      typeof target === 'string' ? Buffer.from(target, 'hex') : target;
+    return Array.from(buf);
+  }
+}


### PR DESCRIPTION
binaryのnumber[]に意味付けをするparser
BleAdvBinaryAnalyzerの上位互換。

- RetrunValueに型情報がつくように変更
- LE/BE/Ascii/Hexなどのパース済みでデータが渡せるように変更
- advertisement以外でも使うので名称を変更

互換性のためBleAdvBinaryAnalyzerも残している（置き換えはしていない）