### PR TITLE
BLEエラーの修正

### DIFF
--- a/src/obniz/libs/embeds/bleHci/protocol/central/gap.ts
+++ b/src/obniz/libs/embeds/bleHci/protocol/central/gap.ts
@@ -461,18 +461,33 @@ export class Gap extends EventEmitter<GapEventTypes> {
           type === LegacyAdvertising_ADV_SCAN_RESP_TO_ADV_IND ||
           type === LegacyAdvertising_ADV_SCAN_RESP_TO_SCAN_IND
         ) {
-          connectable = this._discoveries[address].connectable;
+          // legacy scan response
+          if (previouslyDiscovered) {
+            connectable = this._discoveries[address].connectable;
+          } else {
+            connectable = true; // not specified. fallback to true
+          }
         } else {
+          // legacy advertising
           connectable = type !== LegacyAdvertising_ADV_NONCONN_IND;
         }
       } else {
         connectable = (type & 0b00000001) !== 0;
       }
     } else {
-      if (type === 0x04 && previouslyDiscovered) {
-        connectable = this._discoveries[address].connectable;
+      if (type === 0x04) {
+        // SCAN_RSP
+        if (previouslyDiscovered) {
+          connectable = this._discoveries[address].connectable;
+        } else {
+          connectable = true; // not specified. fallback to true
+        }
+      } else if (type === 0x03) {
+        // ADV_NONCONN_IND
+        connectable = false;
       } else {
-        connectable = type !== 0x03;
+        // ADV_IND, ADV_DIRECT_IND, ADV_SCAN_IND
+        connectable = true;
       }
     }
     this._discoveries[address] = {


### PR DESCRIPTION
下記の条件を使っているときに発生するエラーを抑制
- Binary filterを使ってadvertismentを受信することなくscan responseを受信
- Ble extendedで使用している
- 電波自体はBLE phy 1m

上記の条件が揃うと、connectableなadvertisementかどうかの判定ができないが、そこの考慮漏れの修正
