### PR TITLE
fix: MCP23S08 SPI register read always returning 0xFF

### DIFF
--- a/src/obniz/libs/embeds/mcp23s08.ts
+++ b/src/obniz/libs/embeds/mcp23s08.ts
@@ -84,9 +84,13 @@ export class MCP23S08 {
    * @returns readed value of address
    */
   public async readWait(address: number) {
-    await this.spi.writeWait([this.readSlaveAddress, address]);
-    const ret = await this.spi.writeWait([0x00]);
-    return ret[0];
+    // opcode + address + dummy must be one transaction (CS held low)
+    const ret = await this.spi.writeWait([
+      this.readSlaveAddress,
+      address,
+      0x00,
+    ]);
+    return ret[2];
   }
 
   /**


### PR DESCRIPTION
## Problem

`MCP23S08.readWait()` split the register read into two separate SPI transactions:

```ts
await this.spi.writeWait([this.readSlaveAddress, address]);
const ret = await this.spi.writeWait([0x00]);
```

When the SPI peripheral is started with a `cs` pin, each `writeWait()` is an independent CS-framed transaction. The MCP23S08 resets its command sequence when CS is deasserted, so the second transaction (`0x00`, which is not a valid device opcode) is ignored and MISO stays high-impedance. The read therefore always returned `0xFF`, which made every input-reading API (`readWait`, `readAllGPIOWait`, `inputWait`) report all input pins as `true` regardless of the actual pin state.

## Fix

Send opcode + register address + dummy byte in a single transaction so CS is held low for the whole read, and return the third byte of the response.
